### PR TITLE
Add xgboostserver

### DIFF
--- a/xgboostserver/rockcraft.yaml
+++ b/xgboostserver/rockcraft.yaml
@@ -15,6 +15,9 @@ parts:
         source: https://github.com/SeldonIO/seldon-core
         source-type: git
         source-tag: "v1.16.0"  # Should match 'version' above. version.txt is the same, just without the 'v' prefix
+        # TODO: Use `source-subdir` once issue is fixed
+        # https://github.com/canonical/craft-parts/issues/427
+        source-depth: 1
         python-requirements:
           - servers/xgboostserver/xgboostserver/requirements.txt
         python-packages:

--- a/xgboostserver/rockcraft.yaml
+++ b/xgboostserver/rockcraft.yaml
@@ -1,0 +1,39 @@
+name: xgboostserver
+base: ubuntu:20.04
+version: "1.16.0"  # Should match source-tag below
+summary: Seldon XGBoost Server
+description: |
+  The model server for XGBoost models
+license: Apache-2.0
+
+platforms:
+    amd64:
+
+parts:
+    xgboostserver:
+        plugin: python
+        source: https://github.com/SeldonIO/seldon-core
+        source-type: git
+        source-tag: "v1.16.0"  # Should match 'version' above. version.txt is the same, just without the 'v' prefix
+        # TODO why these reqs are not present in the final image?
+        python-requirements:
+          - servers/xgboostserver/xgboostserver/requirements.txt
+        python-packages:
+          - seldon_core
+            # - scikit-learn==0.20.3
+            # - numpy>=1.8.2
+            # - xgboost==1.4.2
+        override-build: |
+          craftctl default
+          install -D -m755 servers/xgboostserver/xgboostserver/XGBoostServer.py ${CRAFT_PART_INSTALL}/opt/XGBoostServer.py
+        organize:
+          opt/XGBoostServer.py: usr/bin/XGBoostServer.py
+        stage-packages:
+          - python3-venv
+
+services:
+  xgboostserver:
+    override: merge
+    command: /bin/python3 /usr/bin/XGBoostServer.py
+    startup: enabled
+

--- a/xgboostserver/rockcraft.yaml
+++ b/xgboostserver/rockcraft.yaml
@@ -15,14 +15,10 @@ parts:
         source: https://github.com/SeldonIO/seldon-core
         source-type: git
         source-tag: "v1.16.0"  # Should match 'version' above. version.txt is the same, just without the 'v' prefix
-        # TODO why these reqs are not present in the final image?
         python-requirements:
           - servers/xgboostserver/xgboostserver/requirements.txt
         python-packages:
           - seldon_core
-            # - scikit-learn==0.20.3
-            # - numpy>=1.8.2
-            # - xgboost==1.4.2
         override-build: |
           craftctl default
           install -D -m755 servers/xgboostserver/xgboostserver/XGBoostServer.py ${CRAFT_PART_INSTALL}/opt/XGBoostServer.py


### PR DESCRIPTION
TODO:
- [ ] Automate out `version: "1.16.0"` and `source-tag: "v1.16.0"`. At o11y we use [this workflow](https://github.com/canonical/observability/blob/main/.github/workflows/update-rock.yaml).
- [ ] Simplify/remove the `override-build` section
- [ ] Figure out why starting XGBoostServer fails, raising an exception:

```
  File "/lib/python3.8/site-packages/sklearn/externals/joblib/externals/cloudpickle/cloudpickle.py", line 148, in _make_cell_set_template_code
    return types.CodeType(
TypeError: an integer is required (got type bytes)
```