### PR TITLE
feat: add kfam rock

### DIFF
--- a/kfam/rockcraft.yaml
+++ b/kfam/rockcraft.yaml
@@ -17,7 +17,7 @@ services:
     override: replace
     command: "/access-management -cluster-admin admin -userid-header kubeflow-userid -userid-prefix ''"
     startup: enabled
-    user: kfam
+    user: ubuntu
 
 parts:
   kfam:
@@ -39,3 +39,18 @@ parts:
       chmod a+rx $CRAFT_PART_INSTALL/access-management
       cp -r third_party $CRAFT_PART_INSTALL/third_party
       cp -r /root/go/pkg/mod/github.com/hashicorp $CRAFT_PART_INSTALL/third_party/library/
+
+      # security requirement
+      mkdir -p ${CRAFT_PART_INSTALL}/usr/share/ROCK images
+      (echo "# os-release" && cat /etc/os-release && echo "# dpkg-query" && \
+      dpkg-query -f '${db:Status-Abbrev},${binary:Package},${Version},${source:Package},${Source:Version}\n' -W) \
+      > ${CRAFT_PART_INSTALL}/usr/share/ROCK images/dpkg.query
+
+  non-root-user:
+    plugin: nil
+    after: kfam
+    overlay-script: |
+      # Create a user in the $CRAFT_OVERLAY chroot
+      groupadd -R $CRAFT_OVERLAY -g 1001 ubuntu
+      useradd -R $CRAFT_OVERLAY -M -r -u 1001 -g ubuntu ubuntu
+ 

--- a/kfam/rockcraft.yaml
+++ b/kfam/rockcraft.yaml
@@ -5,7 +5,7 @@
 name: kfam
 summary: Kubeflow Access Management API
 description: Kubeflow Access Management API provides fine-grain user-namespace level access control.
-version: "v1.7.0"
+version: "v1.7.0_1"
 license: Apache-2.0
 base: ubuntu:22.04
 

--- a/kfam/rockcraft.yaml
+++ b/kfam/rockcraft.yaml
@@ -8,26 +8,34 @@ description: Kubeflow Access Management API provides fine-grain user-namespace l
 version: "v1.7.0"
 license: Apache-2.0
 base: ubuntu:22.04
+
 platforms:
   amd64:
+
 services:
   access-manager:
     override: replace
-    command: "/manager -userid-header kubeflow-userid -userid-prefix ''"
+    command: "/access-management -cluster-admin admin -userid-header kubeflow-userid -userid-prefix ''"
     startup: enabled
     user: kfam
+
 parts:
   kfam:
-    plugin: dump
-    build-snaps: [go]
-    source: https://github.com/kubeflow/kubeflow
+    plugin: go
+    build-snaps:
+      - go/1.19/stable
+    source: https://github.com/kubeflow/kubeflow.git
     source-subdir: components/access-management
-    source-tag: "v1.7.0"
+    source-type: git
+    source-tag: v1.7.0
     build-environment:
       - CGO_ENABLED: 0
       - GOOS: linux
     override-build: |
-        go build -gcflags 'all=-N -l' -o access-management main.go
-        cp access-management $CRAFT_PART_INSTALL/access-management
-        cp third_party $CRAFT_PART_INSTALL/third_party
-        cp /go/pkg/mod/github.com/hashicorp $CRAFT_PART_INSTALL/third_party/library/
+      # cd into $CRAFT_PART_SRC_WORK due to https://github.com/canonical/craft-parts/issues/427
+      cd $CRAFT_PART_SRC_WORK
+      go mod download
+      go build -gcflags 'all=-N -l' -o $CRAFT_PART_INSTALL/access-management main.go
+      chmod a+rx $CRAFT_PART_INSTALL/access-management
+      cp -r third_party $CRAFT_PART_INSTALL/third_party
+      cp -r /root/go/pkg/mod/github.com/hashicorp $CRAFT_PART_INSTALL/third_party/library/

--- a/kfam/rockcraft.yaml
+++ b/kfam/rockcraft.yaml
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+name: kfam
+summary: Kubeflow Access Management API
+description: Kubeflow Access Management API provides fine-grain user-namespace level access control.
+version: "v1.7.0"
+license: Apache-2.0
+base: ubuntu:22.04
+platforms:
+  amd64:
+services:
+  access-manager:
+    override: replace
+    command: "/manager -userid-header kubeflow-userid -userid-prefix ''"
+    startup: enabled
+    user: kfam
+parts:
+  kfam:
+    plugin: dump
+    build-snaps: [go]
+    source: https://github.com/kubeflow/kubeflow
+    source-subdir: components/access-management
+    source-tag: "v1.7.0"
+    build-environment:
+      - CGO_ENABLED: 0
+      - GOOS: linux
+    override-build: |
+        go build -gcflags 'all=-N -l' -o access-management main.go
+        cp access-management $CRAFT_PART_INSTALL/access-management
+        cp third_party $CRAFT_PART_INSTALL/third_party
+        cp /go/pkg/mod/github.com/hashicorp $CRAFT_PART_INSTALL/third_party/library/


### PR DESCRIPTION
Adds rockcraft.yaml for kfam, the charm associated to this image is kubeflow-profiles-operator.

##### Instructions to test

1. Build the rock
```
rockcraft pack -v
```
3. Import the rock into a local docker registry
```
# This step requires you to install skopeo, which you can do with apt on Ubuntu 20.04 or newer
# https://github.com/containers/skopeo/blob/main/install.md
sudo skopeo --insecure-policy copy oci-archive:<name of the rock file>.rock docker-daemon:kfam:0.1
```
4. Run the container image
```
docker run --rm kfam:0.1
```
##### Output
```
2023-05-11T12:08:08.101Z [pebble] Started daemon.
2023-05-11T12:08:08.108Z [pebble] POST /v1/services 6.247989ms 202
2023-05-11T12:08:08.108Z [pebble] Started default services with change 1.
```

Logging into the container and running the service command `/access-management -cluster-admin admin -userid-header kubeflow-userid -userid-prefix ''`

```
root@c5325f89869c:/# /access-management -cluster-admin admin -userid-header kubeflow-userid -userid-prefix ''
INFO[0000] Server started                               
INFO[0000] could not locate a kubeconfig                
panic: could not locate a kubeconfig

goroutine 1 [running]:
main.main()
        /root/parts/kfam/src/components/access-management/main.go:52 +0x467
```
