### PR TITLE
Build sklearnserver

### DIFF
--- a/sklearnserver/rockcraft.yaml
+++ b/sklearnserver/rockcraft.yaml
@@ -1,0 +1,78 @@
+name: sklearnserver
+summary: An image for Seldon SKLearn Server
+description: |
+  This image is used as part of the Charmed Kubeflow product. The SKLearn Server serves
+  models which have been stored as pickles.
+version: v1.16.0_1 # version format: <KF-upstream-version>_<Charmed-KF-version>
+license: Apache-2.0
+base: ubuntu:20.04
+services:
+  sklearnserver:
+    override: replace
+    summary: "sklearnserver service"
+    startup: enabled
+    # Yet again, use a subshell to jam conda into a working state. Can't use bashrc, because it immediately
+    # exits if PS1 isn't set, so no-go from scripts
+    command: bash -c 'cd /microservice && export PATH=/opt/conda/bin/${PATH} && eval $(/opt/conda/bin/conda shell.bash hook 2> /dev/null) && source /opt/conda/etc/profile.d/conda.sh && conda activate && seldon-core-microservice $MODEL_NAME --service-type $SERVICE_TYPE --persistence $PERSISTENCE'
+    environment:
+      MODEL_NAME: "SKLearnServer"
+      SERVICE_TYPE: "MODEL"
+      PERSISTENCE: "0"
+platforms:
+  amd64:
+
+parts:
+  sklearnserver:
+    plugin: nil
+    source: https://github.com/SeldonIO/seldon-core
+    source-type: git
+    source-tag: v1.16.0
+    override-stage: |
+      export CONDA_DOWNLOAD_VERSION="py38_4.12.0"
+      export CONDA_VERSION="4.13.0"
+      curl -L -o certifi-python-certifi.tar.gz https://github.com/certifi/python-certifi/archive/master.tar.gz
+      curl -L -o ~/miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-${CONDA_DOWNLOAD_VERSION}-Linux-x86_64.sh
+      bash ~/miniconda.sh -b -u -p opt/conda
+      rm ~/miniconda.sh
+      opt/conda/bin/conda install --yes conda=${CONDA_VERSION}
+      opt/conda/bin/conda clean -tipy
+
+      mkdir -p etc/profile.d
+      ln -sf opt/conda/etc/profile.d/conda.sh etc/profile.d/conda.sh
+      echo ". /opt/conda/etc/profile.d/conda.sh" >> ~/.bashrc
+      bash -c "opt/conda/bin/conda init bash"
+      echo "conda activate base" >> ~/.bashrc
+      chgrp -R root opt/conda && chmod -R g+rw opt/conda
+
+      # Use a heredoc to build a temporary script. Craft stages use sh, not bash.
+      cat >> ./build.sh <<EOF
+      #!/usr/bin/bash
+      export PWD=$(pwd)
+      export PATH=./opt/conda/bin:${PATH}
+      eval $(/root/stage/opt/conda/bin/conda shell.bash hook 2> /dev/null)
+
+      conda activate
+      conda activate base
+      cd /root/parts/sklearnserver/src/servers/sklearnserver/sklearnserver
+      pip install -r requirements.txt
+
+      mkdir -p ${PWD}/microservice
+      cp SKLearnServer.py ${PWD}/microservice/
+      EOF
+
+      bash ./build.sh
+      rm build.sh
+
+      # conda writes shebangs with its path everywhere, and in crafting, that will be, for example:
+      # #!/root/stage/opt/conda/...
+      #
+      # Snip off the /root/stage part
+      bash -c "grep -R -E '/root/stage' opt/ 2>/dev/null | grep -v Bin | awk '{split(\$0,out,\":\"); print out[1]}' | uniq | xargs -I{} sed -i -e 's/\/root\/stage//' {}"
+    override-prime: |
+      craftctl default
+      cp -rp ${CRAFT_STAGE}/opt opt/
+
+      # seldon-core-microservice is a trivial wrapper which looks for .py|.exe files in pwd
+      # and blindly executes them, as they should inherit. It doesn't need to be in /microservice,
+      # but it does need to match pebble's workdir
+      install -D -m 755 ${CRAFT_STAGE}/microservice/SKLearnServer.py microservice/SKLearnServer.py


### PR DESCRIPTION
Execution (finally) gives the same output as the upstream image, which is admittedly a Python exception because there's no JOBLIB_FILE from some `seldon_core...model_uri`, but it's close to a working model if not completely there.

Primarily, Conda inside craft is an adventure for a lot of reasons, and while this is the first Rockcraft YAML which successfully jumps through all the right hoops, the patterns here (principally the subshell, invoking `seldon-core-microservice ..`, another subshell during pebble exec) will almost certainly be needed in other Seldon images, and/or other Conda images.