### PR TITLE
KF-2231 Admission webhook Rock

### DIFF
--- a/admission-webhook/rockcraft.yaml
+++ b/admission-webhook/rockcraft.yaml
@@ -1,0 +1,37 @@
+name: admission-webhook
+base: ubuntu:20.04
+version: v1.7.0_1 # version format: <KF-upstream-version>_<Charmed-KF-version>
+summary: An image for Kubeflow's admission-webhook
+description: |
+  Admission webhook controller in general, intercepts requests to the Kubernetes API server, 
+  and can modify and/or validate the requests. Here the admission webhook is implemented to 
+  modify pods based on the available PodDefaults. When a pod creation request is received, 
+  the admission webhook looks up the available PodDefaults which match the pod's label. 
+  It then, mutates the Pod spec according to PodDefault's spec.
+license: Apache-2.0
+
+platforms:
+    amd64:
+
+services:
+  base-admission-webhook:
+    override: merge
+    command: webhook
+    startup: enabled
+
+parts:
+  admission-webhook:
+    plugin: go
+    build-snaps:
+      - go/1.17/stable
+    source: https://github.com/kubeflow/kubeflow.git
+    source-tag: v1.7-branch 
+    build-environment:
+      - CGO_ENABLED: 0
+      - GOOS: linux
+    override-build: |
+      cd components/admission-webhook 
+      go build -o webhook -a .
+      cp webhook $CRAFT_PART_INSTALL/webhook
+    organize:
+      webhook: "bin/webhook"

--- a/admission-webhook/rockcraft.yaml
+++ b/admission-webhook/rockcraft.yaml
@@ -18,6 +18,7 @@ services:
     override: merge
     command: webhook
     startup: enabled
+    user: ubuntu
 
 parts:
   admission-webhook:
@@ -41,7 +42,7 @@ parts:
     after: [admission-webhook]
     overlay-script: |
       # Create a user in the $CRAFT_OVERLAY chroot
-      groupadd -R $CRAFT_OVERLAY -g 1000 admission-webhook
-      useradd -R $CRAFT_OVERLAY -M -r -u 1000 -g admission-webhook admission-webhook
+      groupadd -R $CRAFT_OVERLAY -g 1000 ubuntu
+      useradd -R $CRAFT_OVERLAY -M -r -u 1000 -g ubuntu ubuntu
     override-prime: |
       craftctl default

--- a/admission-webhook/rockcraft.yaml
+++ b/admission-webhook/rockcraft.yaml
@@ -21,6 +21,12 @@ services:
     user: ubuntu
 
 parts:
+  security-team-requirement:
+    plugin: nil
+    override-build: |
+      mkdir -p ${CRAFT_PART_INSTALL}/usr/share/rocks
+      (echo "# os-release" && cat /etc/os-release && echo "# dpkg-query" && dpkg-query -f '${db:Status-Abbrev},${binary:Package},${Version},${source:Package},${Source:Version}\n' -W) > ${CRAFT_PART_INSTALL}/usr/share/rocks/dpkg.query
+
   admission-webhook:
     plugin: go
     build-snaps:
@@ -42,7 +48,7 @@ parts:
     after: [admission-webhook]
     overlay-script: |
       # Create a user in the $CRAFT_OVERLAY chroot
-      groupadd -R $CRAFT_OVERLAY -g 1000 ubuntu
-      useradd -R $CRAFT_OVERLAY -M -r -u 1000 -g ubuntu ubuntu
+      groupadd -R $CRAFT_OVERLAY -g 1001 ubuntu
+      useradd -R $CRAFT_OVERLAY -M -r -u 1001 -g ubuntu ubuntu
     override-prime: |
       craftctl default

--- a/admission-webhook/rockcraft.yaml
+++ b/admission-webhook/rockcraft.yaml
@@ -35,3 +35,13 @@ parts:
       cp webhook $CRAFT_PART_INSTALL/webhook
     organize:
       webhook: "bin/webhook"
+
+  non-root-user:
+    plugin: nil
+    after: [admission-webhook]
+    overlay-script: |
+      # Create a user in the $CRAFT_OVERLAY chroot
+      groupadd -R $CRAFT_OVERLAY -g 1000 admission-webhook
+      useradd -R $CRAFT_OVERLAY -M -r -u 1000 -g admission-webhook admission-webhook
+    override-prime: |
+      craftctl default


### PR DESCRIPTION
Add rockcraft yaml for the admission-webhook ROCK.

Upstream here: https://github.com/kubeflow/kubeflow/tree/master/components/admission-webhook

Test to run: 
```
rockcraft pack --verbosity=trace
sudo skopeo --insecure-policy copy oci-archive:admission-webhook_v1.7.0_1_amd64.rock docker-daemon:admission-webhook_v1.7.0_1_amd64.rock:rock
docker run admission-webhook_v1.7.0_1_amd64.rock:rock
```

Expected error (as there are no certs in local test)
```
2023-05-09T12:30:39.238Z [pebble] Started daemon.
2023-05-09T12:30:39.253Z [pebble] POST /v1/services 15.006094ms 202
2023-05-09T12:30:39.253Z [pebble] Started default services with change 1.
2023-05-09T12:30:39.268Z [pebble] Service "base-admission-webhook" starting: webhook
2023-05-09T12:30:39.273Z [base-admission-webhook] F0509 12:30:39.273371      14 config.go:46] config=main.Config{CertFile:"/etc/webhook/certs/cert.pem", KeyFile:"/etc/webhook/certs/key.pem"} Error: open /etc/webhook/certs/cert.pem: no such file or directory
```