### PR TITLE
Kf 4075 feat unit tests for jupyter pytorch cuda full rock

### DIFF
--- a/jupyter-pytorch-cuda-full/rockcraft.yaml
+++ b/jupyter-pytorch-cuda-full/rockcraft.yaml
@@ -41,7 +41,7 @@ parts:
     override-build: |
       mkdir -p ${CRAFT_PART_INSTALL}/usr/share/rocks
       (echo "# os-release" && cat /etc/os-release && echo "# dpkg-query" && \
-      dpkg-query --root=${CRAFT_PROJECT_DIR}/../bundles/ubuntu-22.04/rootfs/ -f '${db:Status-Abbrev},${binary:Package},${Version},${source:Package},${Source:Version}\n' -W) \
+      dpkg-query -f '${db:Status-Abbrev},${binary:Package},${Version},${source:Package},${Source:Version}\n' -W) \
       > ${CRAFT_PART_INSTALL}/usr/share/rocks/dpkg.query
 
   overlay-pkgs:

--- a/jupyter-pytorch-cuda-full/rockcraft.yaml
+++ b/jupyter-pytorch-cuda-full/rockcraft.yaml
@@ -7,9 +7,9 @@ description: |
 
   Both PyTorch and Jupyter are installed in Conda environment, which is
   automatically activated.
-version: v1.7.0_22.04_1 # version format: <KF-upstream-version>_<base-version>_<Charmed-KF-version>
+version: v1.7.0_20.04_1 # version format: <KF-upstream-version>_<base-version>_<Charmed-KF-version>
 license: Apache-2.0
-base: ubuntu:22.04
+base: ubuntu:20.04
 run-user: _daemon_
 services:
   jupyter:
@@ -17,28 +17,23 @@ services:
     summary: "jupyter-pytorch-cuda-full service"
     startup: enabled
     environment:
-      NB_USER: jovyan
-      NB_UID: 1001
-      NB_PREFIX: /
-      HOME: /home/jovyan
-      SHELL: /bin/bash
-      LANG: en_US.UTF-8
-      LANGUAGE: en_US.UTF-8
-      LC_ALL: en_US.UTF-8
-      PATH: /opt/conda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-      NVIDIA_VISIBLE_DEVICES: all
-      NVIDIA_DRIVER_CAPABILITIES: compute,utility
-      LD_LIBRARY_PATH: /usr/local/nvidia/lib:/usr/local/nvidia/lib64
-    command: /opt/conda/bin/jupyter lab --notebook-dir="/home/jovyan" --ip=0.0.0.0 --no-browser --allow-root --port=8888 --ServerApp.token="" --ServerApp.password="" --ServerApp.allow_origin="*" --ServerApp.base_url="/" --ServerApp.authenticate_prometheus=False
+       NB_USER: jovyan
+       NB_UID: 1001
+       NB_PREFIX: /
+       HOME: /home/jovyan
+       SHELL: /bin/bash
+       LANG: en_US.UTF-8
+       LANGUAGE: en_US.UTF-8
+       LC_ALL: en_US.UTF-8
+       PATH: /opt/conda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+       NVIDIA_VISIBLE_DEVICES: all
+       NVIDIA_DRIVER_CAPABILITIES: compute,utility
+       LD_LIBRARY_PATH: /usr/local/nvidia/lib:/usr/local/nvidia/lib64
+       PYTHONPATH: /opt/conda/lib/python3.8/site-packages/
+    command: ./jupyter lab --notebook-dir="/home/jovyan" --ip=0.0.0.0 --no-browser --allow-root --port=8888 --ServerApp.token="" --ServerApp.password="" --ServerApp.allow_origin="*" --ServerApp.base_url="/" --ServerApp.authenticate_prometheus=False
+    working-dir: /opt/conda/bin/
 platforms:
   amd64:
-
-package-repositories:
-  - type: apt
-    components: [main]
-    suites: [jammy]
-    key-id: 9FD3B784BC1C6FC31A8A0A1C1655A0AB68576280
-    url: https://deb.nodesource.com/node_14.x
 
 parts:
   security-team-requirement:
@@ -151,7 +146,7 @@ parts:
       "${CONDA_BIN}/pip" install --no-cache-dir -r jupyter-requirements.txt
 
       # Generate a jupyter lab config
-      "${CONDA_BIN}/jupyter" lab --generate-config --allow-root
+      "${CONDA_BIN}/jupyter" lab --generate-config
 
       # Install the jupyter-pytorch cuda requirements
       cp $CRAFT_PART_SRC/components/example-notebook-servers/jupyter-pytorch/cuda-requirements.txt cuda-requirements.txt
@@ -186,6 +181,6 @@ parts:
       useradd -R $CRAFT_OVERLAY -M -s /bin/bash -N -u 1001 jovyan
     override-prime: |
       craftctl default
-      chown -R 1001:users home/jovyan
-      chown -R 1001:users bin
-      chown -R 1001:users opt/conda
+      chown -R 584792:users home/jovyan
+      chown -R 584792:users bin
+      chown -R 584792:users opt/conda

--- a/jupyter-pytorch-cuda-full/tests/imports.py
+++ b/jupyter-pytorch-cuda-full/tests/imports.py
@@ -1,0 +1,43 @@
+#
+# This python script tests loading of required modules
+#
+# jupyter packages
+import jupyterlab
+import notebook
+import ipykernel
+
+# pytorch packages
+import torch
+import torchvision
+import torchaudio
+
+# kubeflow packages
+# TO-DO verfiy proper kfp import. Upgrade might be needed.
+#import kfp
+import kfp_server_api
+import kfserving
+
+# common packages
+import bokeh
+import cloudpickle
+import dill
+import ipympl
+import ipywidgets
+import jupyterlab_git
+import matplotlib
+import pandas
+# TO-DO verify how exactly scikit-image is installed
+# /opt/conda/lib/python3.8/site-packages/scikit_image-0.18.1.dist-info
+#import scikit_image
+# TO-DO verify how exactly scikit-learn is installed
+# /opt/conda/lib/python3.8/site-packages/scikit_learn-0.24.2.dist-info
+#import scikit_learn
+import scipy
+import seaborn
+import xgboost
+
+# pytorch packages
+import fastai
+
+# this string is expected by test script
+print("PASSED")

--- a/jupyter-pytorch-cuda-full/tests/test_access.py
+++ b/jupyter-pytorch-cuda-full/tests/test_access.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+#
+#
+from pathlib import Path
+
+import os
+import subprocess
+import time
+import yaml
+
+
+def main():
+    """Test running container and imports."""
+    rock = yaml.safe_load(Path("rockcraft.yaml").read_text())
+    name = rock["name"]
+    rock_version = rock["version"]
+    arch = list(rock["platforms"].keys())[0]
+    rock_image = f"{name}_{rock_version}_{arch}"
+    LOCAL_ROCK_IMAGE = f"{rock_image}:{rock_version}"
+    
+    print(f"Running {LOCAL_ROCK_IMAGE}")
+    container_id = subprocess.run(["docker", "run", "-d", "-p", "8888:8888", LOCAL_ROCK_IMAGE], stdout=subprocess.PIPE).stdout.decode('utf-8')
+    container_id = container_id[0:12]
+
+    # to ensure container is started
+    time.sleep(5)
+
+    # retrieve notebook server URL
+    output = subprocess.run(["curl", "http://127.0.0.1:8888/lab"], stdout=subprocess.PIPE).stdout.decode('utf-8')
+    # cleanup
+    subprocess.run(["docker", "stop", f"{container_id}"])
+    subprocess.run(["docker", "rm", f"{container_id}"])
+
+    # test output
+    assert "JupyterLab" in output
+
+
+if __name__ == "__main__":
+    main()

--- a/jupyter-pytorch-cuda-full/tests/test_imports.py
+++ b/jupyter-pytorch-cuda-full/tests/test_imports.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+#
+#
+from pathlib import Path
+
+import os
+import subprocess
+import yaml
+
+
+def main():
+    """Test running container and imports."""
+    rock = yaml.safe_load(Path("rockcraft.yaml").read_text())
+    name = rock["name"]
+    rock_version = rock["version"]
+    arch = list(rock["platforms"].keys())[0]
+    rock_image = f"{name}_{rock_version}_{arch}"
+    LOCAL_ROCK_IMAGE = f"{rock_image}:{rock_version}"
+    
+    print(f"Running command in {LOCAL_ROCK_IMAGE}")
+    script_command = ["bash", "-c", "export PYTHONPATH=$PYTHONPATH:/opt/conda/lib/python3.8/site-packages/keras/api/keras/wrappers/:/opt/conda/lib/python3.8/site-packages/ && python3 /home/jovyan/imports.py"]
+    pwd = os.getcwd()
+    output = subprocess.run(["docker", "run", "-v", f"{pwd}/tests/:/home/jovyan", LOCAL_ROCK_IMAGE, "exec", "pebble", "exec"] + script_command, stdout=subprocess.PIPE).stdout.decode('utf-8')
+    assert "PASSED" in output
+
+if __name__ == "__main__":
+    main()

--- a/jupyter-pytorch-cuda-full/tests/test_rock.py
+++ b/jupyter-pytorch-cuda-full/tests/test_rock.py
@@ -1,0 +1,28 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+#
+#
+from pathlib import Path
+
+import pytest
+import subprocess
+import yaml
+from pytest_operator.plugin import OpsTest
+
+@pytest.mark.abort_on_fail
+def test_rock(ops_test: OpsTest):
+    """Test rock."""
+    rock = yaml.safe_load(Path("rockcraft.yaml").read_text())
+    name = rock["name"]
+    rock_version = rock["version"]
+    arch = list(rock["platforms"].keys())[0]
+    rock_image = f"{name}_{rock_version}_{arch}"
+    LOCAL_ROCK_IMAGE = f"{rock_image}:{rock_version}"
+
+    # verify ROCK service
+    rock_services = rock["services"]
+    assert rock_services["jupyter"]
+    assert rock_services["jupyter"]["startup"] == "enabled"
+
+    # verify that artifacts are in correct locations
+    subprocess.run(["docker", "run", LOCAL_ROCK_IMAGE, "exec", "ls", "-ls", "/opt/conda/bin/jupyter"], check=True)

--- a/jupyter-pytorch-cuda-full/tox.ini
+++ b/jupyter-pytorch-cuda-full/tox.ini
@@ -1,0 +1,39 @@
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+[tox]
+skipsdist = True
+skip_missing_interpreters = True
+
+[testenv]
+setenv =
+    PYTHONPATH={toxinidir}
+    PYTHONBREAKPOINT=ipdb.set_trace
+    CHARM_REPO=https://github.com/canonical/seldon-core-operator.git
+    CHARM_BRANCH=main
+    LOCAL_CHARM_DIR=charm_repo
+
+[testenv:unit]
+passenv = *
+allowlist_externals =
+    bash
+    tox
+    rockcraft
+deps =
+    charmed-kubeflow-chisme
+    juju~=2.9.0
+    pytest
+    pytest-operator
+    ops
+commands =
+    # build and pack rock
+    rockcraft pack
+    bash -c 'NAME=$(yq eval .name rockcraft.yaml) && \
+             VERSION=$(yq eval .version rockcraft.yaml) && \
+             ARCH=$(yq eval ".platforms | keys" rockcraft.yaml | awk -F " " '\''{ print $2 }'\'') && \
+             ROCK="$\{NAME\}_$\{VERSION\}_$\{ARCH\}" && \
+             sudo skopeo --insecure-policy copy oci-archive:$ROCK.rock docker-daemon:$ROCK:$VERSION && \
+             docker save $ROCK > $ROCK.tar'
+    # run rock tests
+    pytest -v --tb native --show-capture=all --log-cli-level=INFO {posargs} {toxinidir}/tests
+    python {toxinidir}/tests/test_imports.py
+    python {toxinidir}/tests/test_access.py


### PR DESCRIPTION
Unit tests for Jupyter Pytorch Cuda Full ROCK.
These tests verify that all artefacts are in place, that imports can be made in mounted/executed Python script, and that Jupyter Notebook Server is accessible.
    
Summary of changes:
- Tests for testing ROCK integrity.
- Commented out some imports in import test as TO-DOs to be addressed during integation stage. Those might not be required to be tested as importes. Integration should verify this.
- Changed /home/jovyan to be owned by _daemon_
- Added notebook server access test.
- Added unit test to test artifacts, imports, and access.
- Added tox.ini
    
Testing:
```
tox -e unit
```
