### PR TITLE
Feat notebook controller test

### DIFF
--- a/notebook-controller/rockcraft.yaml
+++ b/notebook-controller/rockcraft.yaml
@@ -7,7 +7,7 @@ version: v1.7.0_22.04_1 # version format: <KF-upstream-version>_<base-version>_<
 license: Apache-2.0
 base: ubuntu:22.04
 services:
-  jupyter:
+  jupyter-controller:
     override: replace
     summary: "notebook-controller service"
     startup: enabled

--- a/notebook-controller/tests/test_rock.py
+++ b/notebook-controller/tests/test_rock.py
@@ -1,0 +1,38 @@
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+#
+# Tests for required artifacts to be present in the ROCK image.
+#
+
+from charmed_kubeflow_chisme.rock import CheckRock
+from pathlib import Path
+
+import os
+import logging
+import random
+import pytest
+import string
+import subprocess
+import yaml
+from pytest_operator.plugin import OpsTest
+
+@pytest.fixture()
+def rock_test_env():
+    """Yields a temporary directory and random docker container name, then cleans them up after."""
+    container_name = "".join([str(i) for i in random.choices(string.ascii_lowercase, k=8)])
+    yield container_name
+
+    try:
+        subprocess.run(["docker", "rm", container_name])
+    except Exception:
+        pass
+
+@pytest.mark.abort_on_fail
+def test_rock(ops_test: OpsTest, rock_test_env):
+    """Test rock."""
+    check_rock = CheckRock("rockcraft.yaml")
+    container_name = rock_test_env
+    LOCAL_ROCK_IMAGE = f"{check_rock.get_image_name()}:{check_rock.get_version()}"
+
+    # verify that all artifacts are in correct locations
+    subprocess.run(["docker", "run", LOCAL_ROCK_IMAGE, "exec", "ls", "-la", "/manager"], check=True)

--- a/notebook-controller/tox.ini
+++ b/notebook-controller/tox.ini
@@ -1,0 +1,69 @@
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+[tox]
+skipsdist = True
+skip_missing_interpreters = True
+
+[testenv]
+setenv =
+    PYTHONPATH={toxinidir}
+    PYTHONBREAKPOINT=ipdb.set_trace
+    CHARM_REPO=https://github.com/canonical/notebook-operators.git
+    CHARM_BRANCH=main
+    LOCAL_CHARM_DIR=charm_repo
+
+[testenv:unit]
+passenv = *
+allowlist_externals =
+    bash
+    tox
+    rockcraft
+deps =
+    charmed_kubeflow_chisme
+    juju~=2.9.0
+    pytest
+    pytest-operator
+    ops
+commands =
+    # build and pack rock
+    rockcraft pack
+    bash -c 'NAME=$(yq eval .name rockcraft.yaml) && \
+             VERSION=$(yq eval .version rockcraft.yaml) && \
+             ARCH=$(yq eval ".platforms | keys" rockcraft.yaml | awk -F " " '\''{ print $2 }'\'') && \
+             ROCK="$\{NAME\}_$\{VERSION\}_$\{ARCH\}" && \
+             sudo skopeo --insecure-policy copy oci-archive:$ROCK.rock docker-daemon:$ROCK:$VERSION && \
+             docker save $ROCK > $ROCK.tar'
+    # run rock tests
+    pytest -v --tb native --show-capture=all --log-cli-level=INFO {posargs} {toxinidir}/tests
+
+[testenv:integration]
+passenv = *
+allowlist_externals =
+    bash
+    git
+    rm
+    tox
+    rockcraft
+deps =
+    juju~=2.9.0
+    pytest
+    pytest-operator
+    ops
+commands =
+    # build and pack rock
+    rockcraft pack
+    # clone related charm
+    rm -rf {env:LOCAL_CHARM_DIR}
+    git clone --branch {env:CHARM_BRANCH} {env:CHARM_REPO} {env:LOCAL_CHARM_DIR}
+    # upload rock to docker and microk8s cache, replace charm's container with local rock reference
+    bash -c 'NAME=$(yq eval .name rockcraft.yaml) && \
+             VERSION=$(yq eval .version rockcraft.yaml) && \
+             ARCH=$(yq eval ".platforms | keys" rockcraft.yaml | awk -F " " '\''{ print $2 }'\'') && \
+             ROCK="$\{NAME\}_$\{VERSION\}_$\{ARCH\}" && \
+             sudo skopeo --insecure-policy copy oci-archive:$ROCK.rock docker-daemon:$ROCK:$VERSION && \
+             docker save $ROCK > $ROCK.tar && \
+             microk8s ctr image import $ROCK.tar && \
+             yq e -i ".resources.oci-image.upstream-source=\"$ROCK:$VERSION\"" {env:LOCAL_CHARM_DIR}/charms/jupyter-controller/metadata.yaml'
+    # run charm integration test with rock
+    tox -c {env:LOCAL_CHARM_DIR} -e integration
+

--- a/notebook-controller/tox.ini
+++ b/notebook-controller/tox.ini
@@ -26,6 +26,7 @@ deps =
     ops
 commands =
     # build and pack rock
+    rockcraft clean
     rockcraft pack
     bash -c 'NAME=$(yq eval .name rockcraft.yaml) && \
              VERSION=$(yq eval .version rockcraft.yaml) && \
@@ -41,6 +42,7 @@ passenv = *
 allowlist_externals =
     bash
     git
+    juju
     rm
     tox
     rockcraft
@@ -51,6 +53,7 @@ deps =
     ops
 commands =
     # build and pack rock
+    rockcraft clean
     rockcraft pack
     # clone related charm
     rm -rf {env:LOCAL_CHARM_DIR}
@@ -63,7 +66,9 @@ commands =
              sudo skopeo --insecure-policy copy oci-archive:$ROCK.rock docker-daemon:$ROCK:$VERSION && \
              docker save $ROCK > $ROCK.tar && \
              microk8s ctr image import $ROCK.tar && \
+             microk8s ctr image list | grep notebook-controller && \
              yq e -i ".resources.oci-image.upstream-source=\"$ROCK:$VERSION\"" {env:LOCAL_CHARM_DIR}/charms/jupyter-controller/metadata.yaml'
     # run charm integration test with rock
-    tox -c {env:LOCAL_CHARM_DIR} -e integration
+    juju add-model kubeflow
+    tox -c {env:LOCAL_CHARM_DIR} -e integration -- --model kubeflow
 


### PR DESCRIPTION
Integration tests for notebook-controller ROCK.
These tests re-use Jupyter Controller charm's integration tests.

Summary of changes:
- Added tox.ini with unit and integration tests environments.
- Added test file for unit tests.
- Updated rock to match service with the charm.

