### PR TITLE
feat: update jupyter-scipy rock for 1.8

### DIFF
--- a/jupyter-scipy/rockcraft.yaml
+++ b/jupyter-scipy/rockcraft.yaml
@@ -7,7 +7,7 @@ description: |
 
   Both SciPy and Jupyter are installed in Conda environment, which is
   automatically activated.
-version: v1.7.0_20.04_1 # version format: <KF-upstream-version>_<base-version>_<Charmed-KF-version>
+version: v1.8.0_20.04_1 # version format: <KF-upstream-version>_<base-version>_<Charmed-KF-version>
 license: Apache-2.0
 base: ubuntu:20.04
 run-user: _daemon_
@@ -66,7 +66,7 @@ parts:
   kubectl:
     plugin: nil
     stage-snaps:
-      - kubectl/1.24/stable
+      - kubectl/1.25/stable
     organize:
       kubectl: bin/kubectl
     stage:
@@ -91,7 +91,7 @@ parts:
     plugin: nil
     source: https://github.com/kubeflow/kubeflow
     source-type: git
-    source-tag: v1.7-branch # upstream branch
+    source-tag: v1.8-branch # upstream branch
     build-packages:
       - lsb-release
       - wget

--- a/jupyter-scipy/tests/test_access.py
+++ b/jupyter-scipy/tests/test_access.py
@@ -25,10 +25,10 @@ def main():
     container_id = container_id[0:12]
 
     # to ensure container is started
-    time.sleep(5)
+    time.sleep(10)
 
     # retrieve notebook server URL
-    output = subprocess.run(["curl", "http://127.0.0.1:8888/lab"], stdout=subprocess.PIPE).stdout.decode('utf-8')
+    output = subprocess.run(["curl", "http://0.0.0.0:8888/lab"], stdout=subprocess.PIPE).stdout.decode('utf-8')
     # cleanup
     subprocess.run(["docker", "stop", f"{container_id}"])
     subprocess.run(["docker", "rm", f"{container_id}"])

--- a/jupyter-scipy/tests/test_access.py
+++ b/jupyter-scipy/tests/test_access.py
@@ -8,8 +8,19 @@ from pathlib import Path
 import os
 import subprocess
 import time
+import requests
+import tenacity
 import yaml
 
+
+@tenacity.retry(
+stop=tenacity.stop_after_attempt(5),
+wait=tenacity.wait_fixed(2)
+)
+def check_notebook_server_up(url):
+    response = requests.get(url)
+    response.raise_for_status() # Raise an exception if the request was unsuccessful
+    return response.text
 
 def main():
     """Test running container and imports."""
@@ -24,11 +35,9 @@ def main():
     container_id = subprocess.run(["docker", "run", "-d", "-p", "8888:8888", LOCAL_ROCK_IMAGE], stdout=subprocess.PIPE).stdout.decode('utf-8')
     container_id = container_id[0:12]
 
-    # to ensure container is started
-    time.sleep(10)
+    # Try to reach the notebook server
+    output = check_notebook_server_up("http://0.0.0.0:8888/lab")
 
-    # retrieve notebook server URL
-    output = subprocess.run(["curl", "http://0.0.0.0:8888/lab"], stdout=subprocess.PIPE).stdout.decode('utf-8')
     # cleanup
     subprocess.run(["docker", "stop", f"{container_id}"])
     subprocess.run(["docker", "rm", f"{container_id}"])

--- a/jupyter-scipy/tox.ini
+++ b/jupyter-scipy/tox.ini
@@ -20,7 +20,7 @@ allowlist_externals =
     rockcraft
 deps =
     charmed-kubeflow-chisme
-    juju~=2.9.0
+    juju<4.0
     pytest
     pytest-operator
     ops
@@ -29,7 +29,7 @@ commands =
     rockcraft pack
     bash -c 'NAME=$(yq eval .name rockcraft.yaml) && \
              VERSION=$(yq eval .version rockcraft.yaml) && \
-             ARCH=$(yq eval ".platforms | keys" rockcraft.yaml | awk -F " " '\''{ print $2 }'\'') && \
+             ARCH=$(yq eval -r ".platforms | keys" rockcraft.yaml | cut -d" " -f2) \
              ROCK="$\{NAME\}_$\{VERSION\}_$\{ARCH\}" && \
              sudo skopeo --insecure-policy copy oci-archive:$ROCK.rock docker-daemon:$ROCK:$VERSION && \
              docker save $ROCK > $ROCK.tar'

--- a/jupyter-scipy/tox.ini
+++ b/jupyter-scipy/tox.ini
@@ -23,6 +23,7 @@ deps =
     juju<4.0
     pytest
     pytest-operator
+    tenacity
     ops
 commands =
     # build and pack rock


### PR DESCRIPTION
Update the `jupyter-scipy` rock for 1.8, based on the [upstream image](https://github.com/kubeflow/kubeflow/blob/v1.8-branch/components/example-notebook-servers/jupyter-scipy/Dockerfile) 

## Summary of changes
- change the branch to `v1.8-branch`
- bump the rock version to 1.8
- pin pyjuju to <4.0 in the unit test requirements due to migration to juju 3 in 1.8
- update kubectl to 1.25

## Testing
Note: rock was packed before running the tests
```bash
tox -e unit
unit installed: anyio==4.0.0,asttokens==2.4.0,attrs==23.1.0,backcall==0.2.0,bcrypt==4.0.1,cachetools==5.3.1,certifi==2023.7.22,cffi==1.15.1,charmed-kubeflow-chisme==0.2.0,charset-normalizer==3.2.0,cryptography==41.0.4,decorator==5.1.1,deepdiff==6.2.1,exceptiongroup==1.1.3,executing==1.2.0,google-auth==2.23.0,h11==0.14.0,httpcore==0.18.0,httpx==0.25.0,hvac==1.2.1,idna==3.4,importlib-resources==6.0.1,iniconfig==2.0.0,ipdb==0.13.13,ipython==8.12.2,jedi==0.19.0,Jinja2==3.1.2,jsonschema==4.17.3,juju==3.2.2,kubernetes==28.1.0,lightkube==0.14.0,lightkube-models==1.28.1.4,macaroonbakery==1.3.1,MarkupSafe==2.1.3,matplotlib-inline==0.1.6,mypy-extensions==1.0.0,oauthlib==3.2.2,ops==2.6.0,ordered-set==4.1.0,packaging==23.1,paramiko==2.12.0,parso==0.8.3,pexpect==4.8.0,pickleshare==0.7.5,pkgutil-resolve-name==1.3.10,pluggy==1.3.0,prompt-toolkit==3.0.39,protobuf==3.20.3,ptyprocess==0.7.0,pure-eval==0.2.2,pyasn1==0.5.0,pyasn1-modules==0.3.0,pycparser==2.21,Pygments==2.16.1,pyhcl==0.4.5,pymacaroons==0.13.0,PyNaCl==1.5.0,pyRFC3339==1.1,pyrsistent==0.19.3,pytest==7.4.2,pytest-asyncio==0.21.1,pytest-operator==0.29.0,python-dateutil==2.8.2,pytz==2023.3.post1,PyYAML==6.0.1,requests==2.31.0,requests-oauthlib==1.3.1,rsa==4.9,ruamel.yaml==0.17.32,ruamel.yaml.clib==0.2.7,serialized-data-interface==0.7.0,six==1.16.0,sniffio==1.3.0,stack-data==0.6.2,tenacity==8.2.3,tomli==2.0.1,toposort==1.10,traitlets==5.10.0,typing-extensions==4.8.0,typing-inspect==0.9.0,urllib3==1.26.16,wcwidth==0.2.6,websocket-client==1.6.3,websockets==8.1,zipp==3.17.0
unit run-test-pre: PYTHONHASHSEED='623519335'
unit run-test: commands[0] | bash -c 'NAME=$(yq eval .name rockcraft.yaml) &&  VERSION=$(yq eval .version rockcraft.yaml) &&  ARCH=$(yq eval -r ".platforms | keys" rockcraft.yaml | cut -d" " -f2)  ROCK="${NAME}_${VERSION}_${ARCH}" &&  sudo /snap/rockcraft/current/bin/skopeo --insecure-policy copy oci-archive:$ROCK.rock docker-daemon:$ROCK:$VERSION && docker save $ROCK > $ROCK.tar'
WARNING: test command found but not installed in testenv
  cmd: /usr/bin/bash
  env: /home/ubuntu/kubeflow-rocks/jupyter-scipy/.tox/unit
Maybe you forgot to specify a dependency? See also the whitelist_externals envconfig setting.

DEPRECATION WARNING: this will be an error in tox 4 and above!
Getting image source signatures
Copying blob edaedc954fb5 done  
Copying blob 6c88b0d30890 done  
Copying blob d85af5ccd670 done  
Copying blob c85517882d47 done  
Copying blob fc33d67b13de done  
Copying config c0a58687a0 done  
Writing manifest to image destination
Storing signatures
unit run-test: commands[1] | pytest -v --tb native --show-capture=all --log-cli-level=INFO /home/ubuntu/kubeflow-rocks/jupyter-scipy/tests
=================================================================================== test session starts ===================================================================================
platform linux -- Python 3.8.10, pytest-7.4.2, pluggy-1.3.0 -- /home/ubuntu/kubeflow-rocks/jupyter-scipy/.tox/unit/bin/python
cachedir: .tox/unit/.pytest_cache
rootdir: /home/ubuntu/kubeflow-rocks/jupyter-scipy
plugins: anyio-4.0.0, asyncio-0.21.1, operator-0.29.0
asyncio: mode=strict
collected 1 item                                                                                                                                                                          

tests/test_rock.py::test_rock 
------------------------------------------------------------------------------------- live log setup --------------------------------------------------------------------------------------
INFO     pytest_operator.plugin:plugin.py:647 Adding model microk8s-localhost:test-rock-nrzy on cloud microk8s
PASSED                                                                                                                                                                              [100%]
------------------------------------------------------------------------------------ live log teardown ------------------------------------------------------------------------------------
INFO     pytest_operator.plugin:plugin.py:783 Model status:

Model           Controller          Cloud/Region        Version  SLA          Timestamp
test-rock-nrzy  microk8s-localhost  microk8s/localhost  3.1.5    unsupported  13:37:14Z

INFO     pytest_operator.plugin:plugin.py:789 Juju error logs:


INFO     pytest_operator.plugin:plugin.py:877 Resetting model test-rock-nrzy...
INFO     pytest_operator.plugin:plugin.py:882 Not waiting on reset to complete.
INFO     pytest_operator.plugin:plugin.py:855 Forgetting main...


=================================================================================== 1 passed in 10.17s ====================================================================================
unit run-test: commands[2] | python /home/ubuntu/kubeflow-rocks/jupyter-scipy/tests/test_imports.py
Running command in jupyter-scipy_v1.8.0_20.04_1_amd64:v1.8.0_20.04_1
2023-09-20T13:37:23.434Z [pebble] Started daemon.
2023-09-20T13:37:23.460Z [pebble] POST /v1/exec 24.80643ms 202
2023-09-20T13:37:23.464Z [pebble] GET /v1/tasks/1/websocket/control 2.319556ms 200
2023-09-20T13:37:23.465Z [pebble] GET /v1/tasks/1/websocket/stdio 136.037µs 200
2023-09-20T13:37:23.465Z [pebble] GET /v1/tasks/1/websocket/stderr 61.359µs 200
2023-09-20T13:37:23.483Z [pebble] POST /v1/exec 7.35305ms 202
2023-09-20T13:37:23.492Z [pebble] GET /v1/tasks/2/websocket/control 7.976638ms 200
2023-09-20T13:37:23.494Z [pebble] GET /v1/tasks/2/websocket/stdio 90.163µs 200
2023-09-20T13:37:23.495Z [pebble] GET /v1/tasks/2/websocket/stderr 73.406µs 200
/opt/conda/lib/python3.8/site-packages/azure/storage/blob/_deserialization.py:641: SyntaxWarning: "is" with a literal. Did you mean "=="?
  elif num_empty_lines is 2:
/opt/conda/lib/python3.8/site-packages/azure/storage/blob/_serialization.py:189: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if requests is None or len(requests) is 0:
/opt/conda/lib/python3.8/site-packages/azure/storage/blob/_serialization.py:301: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  if len(serialized_query) is not 0:
/opt/conda/lib/python3.8/site-packages/azure/storage/blob/_upload_chunking.py:409: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if n is 0 or self._buffer.closed:
/opt/conda/lib/python3.8/site-packages/azure/storage/blob/baseblobservice.py:1071: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  if lease_duration is not -1 and \
/opt/conda/lib/python3.8/site-packages/azure/storage/blob/baseblobservice.py:2779: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  if lease_duration is not -1 and \
/opt/conda/lib/python3.8/site-packages/azure/storage/common/_connection.py:82: SyntaxWarning: "is" with a literal. Did you mean "=="?
  self.protocol = self.protocol if parsed_url.scheme is '' else parsed_url.scheme
/opt/conda/lib/python3.8/site-packages/azure/storage/blob/blockblobservice.py:608: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  while len(data) < count and len(data_chunk) is not 0:
[I 230920 13:37:32 utils:157] NumExpr defaulting to 8 threads.
[I 230920 13:37:34 font_manager:1443] generated new fontManager
2023-09-20T13:37:39.110Z [pebble] GET /v1/changes/2/wait 15.614794013s 200
2023-09-20T13:37:39.133Z [pebble] GET /v1/changes/1/wait 15.667420344s 200
unit run-test: commands[3] | python /home/ubuntu/kubeflow-rocks/jupyter-scipy/tests/test_access.py
Running jupyter-scipy_v1.8.0_20.04_1_amd64:v1.8.0_20.04_1
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  3914  100  3914    0     0   318k      0 --:--:-- --:--:-- --:--:--  347k
a8385415c4a7
a8385415c4a7
_________________________________________________________________________________________ summary _________________________________________________________________________________________
  unit: commands succeeded
  congratulations :)
```