### PR TITLE
feat: update jupyter-tensorflow-full rock for 1.8

### DIFF
--- a/jupyter-tensorflow-full/rockcraft.yaml
+++ b/jupyter-tensorflow-full/rockcraft.yaml
@@ -21,8 +21,9 @@ services:
     summary: "jupyter-tensorflow-full service"
     startup: enabled
     environment:
-      NB_USER: jovyan
-      NB_UID: 1001
+      # The following environment variables need to be specified in the Pod's environment, and not hardcoded.
+      #HOME: ""
+      #NB_PREFIX: ""
       NB_PREFIX: /
       HOME: /home/jovyan
       SHELL: /bin/bash
@@ -31,7 +32,7 @@ services:
       LC_ALL: en_US.UTF-8
       PATH: /opt/conda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
       PYTHONPATH: /opt/conda/lib/python3.8/site-packages/
-    command: ./jupyter lab --notebook-dir="/home/jovyan" --ip=0.0.0.0 --no-browser --port=8888 --ServerApp.token="" --ServerApp.password="" --ServerApp.allow_origin="*" --ServerApp.base_url="/" --ServerApp.authenticate_prometheus=False
+    command: bash -c './jupyter lab --notebook-dir=${HOME} --ip=0.0.0.0 --no-browser --port=8888 --ServerApp.token="" --ServerApp.password="" --ServerApp.allow_origin="*" --ServerApp.base_url=${NB_PREFIX} --ServerApp.authenticate_prometheus=False'
     working-dir: /opt/conda/bin/
 platforms:
   amd64:

--- a/jupyter-tensorflow-full/rockcraft.yaml
+++ b/jupyter-tensorflow-full/rockcraft.yaml
@@ -11,7 +11,7 @@ description: |
 
   Both Tensorflow and Jupyter are installed in Conda environment, which is
   automatically activated.
-version: v1.7.0_20.04_1
+version: v1.8.0_20.04_1
 license: Apache-2.0
 base: ubuntu:20.04
 run-user: _daemon_
@@ -69,7 +69,7 @@ parts:
   kubectl:
     plugin: nil
     stage-snaps:
-      - kubectl/1.24/stable
+      - kubectl/1.25/stable
     organize:
       kubectl: bin/kubectl
     stage:
@@ -94,7 +94,7 @@ parts:
     plugin: nil
     source: https://github.com/kubeflow/kubeflow
     source-type: git
-    source-tag: v1.7-branch # upstream branch
+    source-tag: v1.8-branch # upstream branch
     build-packages:
       - lsb-release
       - wget

--- a/jupyter-tensorflow-full/rockcraft.yaml
+++ b/jupyter-tensorflow-full/rockcraft.yaml
@@ -1,7 +1,7 @@
 # Based on the following Dockerfiles:
-# https://github.com/kubeflow/kubeflow/blob/v1.7-branch/components/example-notebook-servers/base/Dockerfile
-# https://github.com/kubeflow/kubeflow/blob/v1.7-branch/components/example-notebook-servers/jupyter/Dockerfile
-# https://github.com/kubeflow/kubeflow/blob/v1.7-branch/components/example-notebook-servers/jupyter-tensorflow-full/cpu.Dockerfile
+# https://github.com/kubeflow/kubeflow/blob/v1.8-branch/components/example-notebook-servers/base/Dockerfile
+# https://github.com/kubeflow/kubeflow/blob/v1.8-branch/components/example-notebook-servers/jupyter/Dockerfile
+# https://github.com/kubeflow/kubeflow/blob/v1.8-branch/components/example-notebook-servers/jupyter-tensorflow-full/cpu.Dockerfile
 name: jupyter-tensorflow-full
 summary: An image for using Jupyter & Tensorflow on CPUs
 description: |

--- a/jupyter-tensorflow-full/tests/imports.py
+++ b/jupyter-tensorflow-full/tests/imports.py
@@ -1,0 +1,24 @@
+#
+# This python script tests loading of required modules
+#
+import tensorflow as tf
+import kfp
+import kfp_server_api
+import kfserving
+import bokeh
+import cloudpickle
+import dill
+import ipympl
+import ipywidgets
+import jupyterlab_git
+import matplotlib
+import pandas
+# TO-DO verify how exactly scikit-image is installed
+#import scikit_image
+import scikit_learn
+import scipy
+import seaborn
+import xgboost
+
+# this string is expected by test script
+print("PASSED")

--- a/jupyter-tensorflow-full/tests/imports.py
+++ b/jupyter-tensorflow-full/tests/imports.py
@@ -1,10 +1,19 @@
 #
 # This python script tests loading of required modules
 #
-import tensorflow as tf
-import kfp
+
+# jupyter packages
+import jupyterlab
+import notebook
+import ipykernel
+
+# kubeflow packages
+# TO-DO verfiy proper kfp import. Upgrade might be needed.
+#import kfp
 import kfp_server_api
 import kfserving
+
+# common packages
 import bokeh
 import cloudpickle
 import dill
@@ -19,6 +28,9 @@ import scikit_learn
 import scipy
 import seaborn
 import xgboost
+
+# tensorflow packages
+import tensorflow
 
 # this string is expected by test script
 print("PASSED")

--- a/jupyter-tensorflow-full/tests/test_access.py
+++ b/jupyter-tensorflow-full/tests/test_access.py
@@ -25,10 +25,10 @@ def main():
     container_id = container_id[0:12]
 
     # to ensure container is started
-    time.sleep(5)
+    time.sleep(10)
 
     # retrieve notebook server URL
-    output = subprocess.run(["curl", "http://127.0.0.1:8888/lab"], stdout=subprocess.PIPE).stdout.decode('utf-8')
+    output = subprocess.run(["curl", "http://0.0.0.0:8888/lab"], stdout=subprocess.PIPE).stdout.decode('utf-8')
     # cleanup
     subprocess.run(["docker", "stop", f"{container_id}"])
     subprocess.run(["docker", "rm", f"{container_id}"])

--- a/jupyter-tensorflow-full/tests/test_imports.py
+++ b/jupyter-tensorflow-full/tests/test_imports.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+#
+#
+from pathlib import Path
+
+import os
+import subprocess
+import yaml
+
+
+def main():
+    """Test running container and imports."""
+    rock = yaml.safe_load(Path("rockcraft.yaml").read_text())
+    name = rock["name"]
+    rock_version = rock["version"]
+    arch = list(rock["platforms"].keys())[0]
+    rock_image = f"{name}_{rock_version}_{arch}"
+    LOCAL_ROCK_IMAGE = f"{rock_image}:{rock_version}"
+    
+    print(f"Running command in {LOCAL_ROCK_IMAGE}")
+    script_command = ["bash", "-c", "export PYTHONPATH=$PYTHONPATH:/opt/conda/lib/python3.8/site-packages/keras/api/keras/wrappers/:/opt/conda/lib/python3.8/site-packages/ && python3 /home/jovyan/imports.py"]
+    pwd = os.getcwd()
+    output = subprocess.run(["docker", "run", "-v", f"{pwd}/tests/:/home/jovyan", LOCAL_ROCK_IMAGE, "exec", "pebble", "exec"] + script_command, stdout=subprocess.PIPE).stdout.decode('utf-8')
+    assert "PASSED" in output
+
+if __name__ == "__main__":
+    main()

--- a/jupyter-tensorflow-full/tox.ini
+++ b/jupyter-tensorflow-full/tox.ini
@@ -35,4 +35,5 @@ commands =
              docker save $ROCK > $ROCK.tar'
     # run rock tests
     pytest -v --tb native --show-capture=all --log-cli-level=INFO {posargs} {toxinidir}/tests
+    python {toxinidir}/tests/test_imports.py
     python {toxinidir}/tests/test_access.py

--- a/jupyter-tensorflow-full/tox.ini
+++ b/jupyter-tensorflow-full/tox.ini
@@ -20,7 +20,7 @@ allowlist_externals =
     rockcraft
 deps =
     charmed-kubeflow-chisme
-    juju~=2.9.0
+    juju<4.0
     pytest
     pytest-operator
     ops
@@ -29,11 +29,10 @@ commands =
     rockcraft pack
     bash -c 'NAME=$(yq eval .name rockcraft.yaml) && \
              VERSION=$(yq eval .version rockcraft.yaml) && \
-             ARCH=$(yq eval ".platforms | keys" rockcraft.yaml | awk -F " " '\''{ print $2 }'\'') && \
+             ARCH=$(yq eval -r ".platforms | keys" rockcraft.yaml | cut -d" " -f2) && \
              ROCK="$\{NAME\}_$\{VERSION\}_$\{ARCH\}" && \
              sudo skopeo --insecure-policy copy oci-archive:$ROCK.rock docker-daemon:$ROCK:$VERSION && \
              docker save $ROCK > $ROCK.tar'
     # run rock tests
     pytest -v --tb native --show-capture=all --log-cli-level=INFO {posargs} {toxinidir}/tests
-    python {toxinidir}/tests/test_imports.py
     python {toxinidir}/tests/test_access.py


### PR DESCRIPTION
Update the `jupyter-tensorflow-full` rock for 1.8, based on the [upstream image](https://github.com/kubeflow/kubeflow/blob/v1.8-branch/components/example-notebook-servers/jupyter-tensorflow-full/cpu.Dockerfile) 

## Summary of changes
- change the branch to `v1.8-branch`
- bump the rock version to 1.8
- pin pyjuju to <4.0 in the unit test requirements due to migration to juju 3 in 1.8
- update kubectl to 1.25

## Testing
Note: the rock was built before running the test
```bash
tox -e unit
unit installed: anyio==4.0.0,asttokens==2.4.0,attrs==23.1.0,backcall==0.2.0,bcrypt==4.0.1,cachetools==5.3.1,certifi==2023.7.22,cffi==1.15.1,charmed-kubeflow-chisme==0.2.0,charset-normalizer==3.2.0,cryptography==41.0.4,decorator==5.1.1,deepdiff==6.2.1,exceptiongroup==1.1.3,executing==1.2.0,google-auth==2.23.0,h11==0.14.0,httpcore==0.18.0,httpx==0.25.0,hvac==1.2.1,idna==3.4,importlib-resources==6.1.0,iniconfig==2.0.0,ipdb==0.13.13,ipython==8.12.2,jedi==0.19.0,Jinja2==3.1.2,jsonschema==4.17.3,juju==3.2.2,kubernetes==28.1.0,lightkube==0.14.0,lightkube-models==1.28.1.4,macaroonbakery==1.3.1,MarkupSafe==2.1.3,matplotlib-inline==0.1.6,mypy-extensions==1.0.0,oauthlib==3.2.2,ops==2.6.0,ordered-set==4.1.0,packaging==23.1,paramiko==2.12.0,parso==0.8.3,pexpect==4.8.0,pickleshare==0.7.5,pkgutil-resolve-name==1.3.10,pluggy==1.3.0,prompt-toolkit==3.0.39,protobuf==3.20.3,ptyprocess==0.7.0,pure-eval==0.2.2,pyasn1==0.5.0,pyasn1-modules==0.3.0,pycparser==2.21,Pygments==2.16.1,pyhcl==0.4.5,pymacaroons==0.13.0,PyNaCl==1.5.0,pyRFC3339==1.1,pyrsistent==0.19.3,pytest==7.4.2,pytest-asyncio==0.21.1,pytest-operator==0.29.0,python-dateutil==2.8.2,pytz==2023.3.post1,PyYAML==6.0.1,requests==2.31.0,requests-oauthlib==1.3.1,rsa==4.9,ruamel.yaml==0.17.32,ruamel.yaml.clib==0.2.7,serialized-data-interface==0.7.0,six==1.16.0,sniffio==1.3.0,stack-data==0.6.2,tenacity==8.2.3,tomli==2.0.1,toposort==1.10,traitlets==5.10.0,typing-extensions==4.8.0,typing-inspect==0.9.0,urllib3==1.26.16,wcwidth==0.2.6,websocket-client==1.6.3,websockets==8.1,zipp==3.17.0
unit run-test-pre: PYTHONHASHSEED='4273105998'
unit run-test: commands[0] | pytest -v --tb native --show-capture=all --log-cli-level=INFO /home/ubuntu/kubeflow-rocks/jupyter-tensorflow-full/tests
====================================================================================== test session starts ======================================================================================
platform linux -- Python 3.8.10, pytest-7.4.2, pluggy-1.3.0 -- /home/ubuntu/kubeflow-rocks/jupyter-tensorflow-full/.tox/unit/bin/python
cachedir: .tox/unit/.pytest_cache
rootdir: /home/ubuntu/kubeflow-rocks/jupyter-tensorflow-full
plugins: anyio-4.0.0, asyncio-0.21.1, operator-0.29.0
asyncio: mode=strict
collected 1 item                                                                                                                                                                                

tests/test_rock.py::test_rock 
---------------------------------------------------------------------------------------- live log setup -----------------------------------------------------------------------------------------
INFO     pytest_operator.plugin:plugin.py:647 Adding model microk8s-localhost:test-rock-e1rg on cloud microk8s
PASSED                                                                                                                                                                                    [100%]
--------------------------------------------------------------------------------------- live log teardown ---------------------------------------------------------------------------------------
INFO     pytest_operator.plugin:plugin.py:783 Model status:

Model           Controller          Cloud/Region        Version  SLA          Timestamp
test-rock-e1rg  microk8s-localhost  microk8s/localhost  3.1.5    unsupported  09:49:55Z

INFO     pytest_operator.plugin:plugin.py:789 Juju error logs:


INFO     pytest_operator.plugin:plugin.py:877 Resetting model test-rock-e1rg...
INFO     pytest_operator.plugin:plugin.py:882 Not waiting on reset to complete.
INFO     pytest_operator.plugin:plugin.py:855 Forgetting main...


====================================================================================== 1 passed in 10.21s =======================================================================================
unit run-test: commands[1] | python /home/ubuntu/kubeflow-rocks/jupyter-tensorflow-full/tests/test_access.py
Running jupyter-tensorflow-full_v1.8.0_20.04_1_amd64:v1.8.0_20.04_1
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  3914  100  3914    0     0   254k      0 --:--:-- --:--:-- --:--:--  254k
84ab5d20dbeb
84ab5d20dbeb
____________________________________________________________________________________________ summary ____________________________________________________________________________________________
  unit: commands succeeded
  congratulations :)
```