### PR TITLE
feat: update notebook-controller rock for 1.8

### DIFF
--- a/notebook-controller/rockcraft.yaml
+++ b/notebook-controller/rockcraft.yaml
@@ -3,14 +3,14 @@ summary: An image for Jupyter notebook controller
 description: |
   This image is used as part of the Charmed Kubeflow product. The controller allows users to
   create a custom resource "Notebook" (jupyter notebook).
-version: v1.7.0_22.04_1 # version format: <KF-upstream-version>_<base-version>_<Charmed-KF-version>
+version: v1.8.0_22.04_1 # version format: <KF-upstream-version>_<base-version>_<Charmed-KF-version>
 license: Apache-2.0
 base: ubuntu:22.04
 services:
   jupyter:
     override: replace
     summary: "notebook-controller service"
-    startup: enabled
+    startup: disabled # disabled because service is started by /manager command
     user: ubuntu
     command: "/manager"
 platforms:
@@ -21,7 +21,7 @@ parts:
     plugin: go
     source: https://github.com/kubeflow/kubeflow
     source-type: git
-    source-tag: v1.7-branch # upstream branch
+    source-tag: v1.8-branch # upstream branch
     build-snaps:
       - go
     build-packages:

--- a/notebook-controller/rockcraft.yaml
+++ b/notebook-controller/rockcraft.yaml
@@ -7,10 +7,10 @@ version: v1.8.0_22.04_1 # version format: <KF-upstream-version>_<base-version>_<
 license: Apache-2.0
 base: ubuntu:22.04
 services:
-  jupyter:
+  jupyter-controller:
     override: replace
     summary: "notebook-controller service"
-    startup: disabled # disabled because service is started by /manager command
+    startup: enabled
     user: ubuntu
     command: "/manager"
 platforms:

--- a/notebook-controller/tox.ini
+++ b/notebook-controller/tox.ini
@@ -1,0 +1,45 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+[tox]
+skipsdist = True
+skip_missing_interpreters = True
+
+[testenv]
+setenv =
+    PYTHONPATH={toxinidir}
+    PYTHONBREAKPOINT=ipdb.set_trace
+    CHARM_REPO=https://github.com/canonical/notebook-operators.git
+    CHARM_BRANCH=main
+    LOCAL_CHARM_DIR=charm_repo
+
+
+[testenv:integration]
+passenv = *
+allowlist_externals =
+    bash
+    git
+    rm
+    tox
+    rockcraft
+deps =
+    juju<4.0
+    pytest
+    pytest-operator
+    ops
+commands =
+    # build and pack rock
+    rockcraft pack
+    # clone related charm
+    rm -rf {env:LOCAL_CHARM_DIR}
+    git clone --branch {env:CHARM_BRANCH} {env:CHARM_REPO} {env:LOCAL_CHARM_DIR}
+    # upload rock to docker and microk8s cache, replace charm's container with local rock reference
+    bash -c 'NAME=$(yq eval .name rockcraft.yaml) && \
+             VERSION=$(yq eval .version rockcraft.yaml) && \
+             ARCH=$(yq eval -r ".platforms | keys" rockcraft.yaml | cut -d" " -f2) && \
+             ROCK="$\{NAME\}_$\{VERSION\}_$\{ARCH\}" && \
+             sudo /snap/rockcraft/current/bin/skopeo --insecure-policy copy oci-archive:$ROCK.rock docker-daemon:$ROCK:$VERSION && \
+             docker save $ROCK > $ROCK.tar && \
+             microk8s ctr image import $ROCK.tar && \
+             yq e -i ".resources.oci-image.upstream-source=\"$ROCK:$VERSION\"" {env:LOCAL_CHARM_DIR}/charms/jupyter-controller/metadata.yaml'
+    # run charm integration test with rock
+    tox -c {env:LOCAL_CHARM_DIR} -e controller-integration


### PR DESCRIPTION
Update the `notebook-controller` rock for 1.8, based on the [upstream image](https://github.com/kubeflow/kubeflow/blob/v1.8-branch/components/notebook-controller/Dockerfile) 

## Summary of changes
- add tox.ini with charm integration tests
- change the branch to `v1.8-branch`
- bump the rock version to 1.8
- pin pyjuju to <4.0 in the test requirements due to migration to juju 3 in 1.8
- fix the service name to match the pebble service in the charm

## Testing
Run the charm integration tests
<details>
<summary>Test logs</summary>

```bash
tox -e integration
integration installed: asttokens==2.4.0,backcall==0.2.0,bcrypt==4.0.1,cachetools==5.3.1,certifi==2023.7.22,cffi==1.15.1,charset-normalizer==3.2.0,cryptography==41.0.4,decorator==5.1.1,exceptiongroup==1.1.3,executing==1.2.0,google-auth==2.23.0,hvac==1.2.1,idna==3.4,iniconfig==2.0.0,ipdb==0.13.13,ipython==8.12.2,jedi==0.19.0,Jinja2==3.1.2,juju==3.2.2,kubernetes==28.1.0,macaroonbakery==1.3.1,MarkupSafe==2.1.3,matplotlib-inline==0.1.6,mypy-extensions==1.0.0,oauthlib==3.2.2,ops==2.6.0,packaging==23.1,paramiko==2.12.0,parso==0.8.3,pexpect==4.8.0,pickleshare==0.7.5,pluggy==1.3.0,prompt-toolkit==3.0.39,protobuf==3.20.3,ptyprocess==0.7.0,pure-eval==0.2.2,pyasn1==0.5.0,pyasn1-modules==0.3.0,pycparser==2.21,Pygments==2.16.1,pyhcl==0.4.5,pymacaroons==0.13.0,PyNaCl==1.5.0,pyRFC3339==1.1,pytest==7.4.2,pytest-asyncio==0.21.1,pytest-operator==0.29.0,python-dateutil==2.8.2,pytz==2023.3.post1,PyYAML==6.0.1,requests==2.31.0,requests-oauthlib==1.3.1,rsa==4.9,six==1.16.0,stack-data==0.6.2,tomli==2.0.1,toposort==1.10,traitlets==5.10.0,typing-extensions==4.8.0,typing-inspect==0.9.0,urllib3==1.26.16,wcwidth==0.2.6,websocket-client==1.6.3,websockets==8.1
integration run-test-pre: PYTHONHASHSEED='3644380827'
integration run-test: commands[0] | rockcraft pack
WARNING: test command found but not installed in testenv
  cmd: /snap/bin/rockcraft
  env: /home/ubuntu/kubeflow-rocks/notebook-controller/.tox/integration
Maybe you forgot to specify a dependency? See also the whitelist_externals envconfig setting.

DEPRECATION WARNING: this will be an error in tox 4 and above!
^CTraceback (most recent call last):
  File "/snap/rockcraft/1014/bin/rockcraft", line 5, in <module>
    from rockcraft.cli import run
  File "/snap/rockcraft/1014/lib/python3.8/site-packages/rockcraft/cli.py", line 23, in <module>
    import craft_cli
  File "/snap/rockcraft/1014/lib/python3.8/site-packages/craft_cli/__init__.py", line 32, in <module>
    from .messages import EmitterMode, emit  # noqa: F401 ; isort:skip
  File "/snap/rockcraft/1014/lib/python3.8/site-packages/craft_cli/messages.py", line 46, in <module>
    from craft_cli.printer import Printer
  File "/snap/rockcraft/1014/lib/python3.8/site-packages/craft_cli/printer.py", line 25, in <module>
    from dataclasses import dataclass, field
  File "/snap/rockcraft/1014/usr/lib/python3.8/dataclasses.py", line 5, in <module>
    import inspect
KeyboardInterrupt
ERROR: got KeyboardInterrupt signal
_____________________________________________________________________________ summary ______________________________________________________________________________
ERROR:   integration: keyboardinterrupt
ubuntu@ip-172-31-18-195:~/kubeflow-rocks/notebook-controller$ tox -e integration
integration installed: asttokens==2.4.0,backcall==0.2.0,bcrypt==4.0.1,cachetools==5.3.1,certifi==2023.7.22,cffi==1.15.1,charset-normalizer==3.2.0,cryptography==41.0.4,decorator==5.1.1,exceptiongroup==1.1.3,executing==1.2.0,google-auth==2.23.0,hvac==1.2.1,idna==3.4,iniconfig==2.0.0,ipdb==0.13.13,ipython==8.12.2,jedi==0.19.0,Jinja2==3.1.2,juju==3.2.2,kubernetes==28.1.0,macaroonbakery==1.3.1,MarkupSafe==2.1.3,matplotlib-inline==0.1.6,mypy-extensions==1.0.0,oauthlib==3.2.2,ops==2.6.0,packaging==23.1,paramiko==2.12.0,parso==0.8.3,pexpect==4.8.0,pickleshare==0.7.5,pluggy==1.3.0,prompt-toolkit==3.0.39,protobuf==3.20.3,ptyprocess==0.7.0,pure-eval==0.2.2,pyasn1==0.5.0,pyasn1-modules==0.3.0,pycparser==2.21,Pygments==2.16.1,pyhcl==0.4.5,pymacaroons==0.13.0,PyNaCl==1.5.0,pyRFC3339==1.1,pytest==7.4.2,pytest-asyncio==0.21.1,pytest-operator==0.29.0,python-dateutil==2.8.2,pytz==2023.3.post1,PyYAML==6.0.1,requests==2.31.0,requests-oauthlib==1.3.1,rsa==4.9,six==1.16.0,stack-data==0.6.2,tomli==2.0.1,toposort==1.10,traitlets==5.10.0,typing-extensions==4.8.0,typing-inspect==0.9.0,urllib3==1.26.16,wcwidth==0.2.6,websocket-client==1.6.3,websockets==8.1
integration run-test-pre: PYTHONHASHSEED='1969858075'
integration run-test: commands[0] | rockcraft pack
WARNING: test command found but not installed in testenv
  cmd: /snap/bin/rockcraft
  env: /home/ubuntu/kubeflow-rocks/notebook-controller/.tox/integration
Maybe you forgot to specify a dependency? See also the whitelist_externals envconfig setting.

DEPRECATION WARNING: this will be an error in tox 4 and above!
Retrieved base ubuntu:22.04 for amd64                                                                                                                              
Extracted ubuntu:22.04                                                                                                                                             
Executed: skip pull notebook-controller (already ran)                                                                                                              
Executed: skip pull non-root-user (already ran)                                                                                                                    
Executed: skip pull pebble (already ran)                                                                                                                           
Executed: skip overlay notebook-controller (already ran)                                                                                                           
Executed: skip overlay non-root-user (already ran)                                                                                                                 
Executed: skip overlay pebble (already ran)                                                                                                                        
Executed: skip build notebook-controller (already ran)                                                                                                             
Executed: skip build non-root-user (already ran)                                                                                                                   
Executed: skip build pebble (already ran)                                                                                                                          
Executed: skip stage notebook-controller (already ran)                                                                                                             
Executed: skip stage non-root-user (already ran)                                                                                                                   
Executed: skip stage pebble (already ran)                                                                                                                          
Executed: skip prime notebook-controller (already ran)                                                                                                             
Executed: skip prime non-root-user (already ran)                                                                                                                   
Executed: skip prime pebble (already ran)                                                                                                                          
Executed parts lifecycle                                                                                                                                           
Exported to OCI archive 'notebook-controller_v1.8.0_22.04_1_amd64.rock'                                                                                            
integration run-test: commands[1] | rm -rf charm_repo
WARNING: test command found but not installed in testenv
  cmd: /usr/bin/rm
  env: /home/ubuntu/kubeflow-rocks/notebook-controller/.tox/integration
Maybe you forgot to specify a dependency? See also the whitelist_externals envconfig setting.

DEPRECATION WARNING: this will be an error in tox 4 and above!
integration run-test: commands[2] | git clone --branch main https://github.com/canonical/notebook-operators.git charm_repo
WARNING: test command found but not installed in testenv
  cmd: /usr/bin/git
  env: /home/ubuntu/kubeflow-rocks/notebook-controller/.tox/integration
Maybe you forgot to specify a dependency? See also the whitelist_externals envconfig setting.

DEPRECATION WARNING: this will be an error in tox 4 and above!
Cloning into 'charm_repo'...
remote: Enumerating objects: 4172, done.
remote: Counting objects: 100% (704/704), done.
remote: Compressing objects: 100% (287/287), done.
remote: Total 4172 (delta 518), reused 520 (delta 406), pack-reused 3468
Receiving objects: 100% (4172/4172), 1.60 MiB | 9.29 MiB/s, done.
Resolving deltas: 100% (1945/1945), done.
integration run-test: commands[3] | bash -c 'NAME=$(yq eval .name rockcraft.yaml) &&  VERSION=$(yq eval .version rockcraft.yaml) &&  ARCH=$(yq eval -r ".platforms | keys" rockcraft.yaml | cut -d" " -f2) &&  ROCK="${NAME}_${VERSION}_${ARCH}" &&  sudo /snap/rockcraft/current/bin/skopeo --insecure-policy copy oci-archive:$ROCK.rock docker-daemon:$ROCK:$VERSION &&  docker save $ROCK > $ROCK.tar &&  microk8s ctr image import $ROCK.tar && yq e -i ".resources.oci-image.upstream-source=\"$ROCK:$VERSION\"" charm_repo/charms/jupyter-controller/metadata.yaml'
WARNING: test command found but not installed in testenv
  cmd: /usr/bin/bash
  env: /home/ubuntu/kubeflow-rocks/notebook-controller/.tox/integration
Maybe you forgot to specify a dependency? See also the whitelist_externals envconfig setting.

DEPRECATION WARNING: this will be an error in tox 4 and above!
Getting image source signatures
Copying blob 445a6a12be2b done  
Copying blob 8b316bdc4987 done  
Copying blob 0087fe1f3fa7 done  
Copying blob b4668af10b82 done  
Copying config 7167409b09 done  
Writing manifest to image destination
Storing signatures
unpacking docker.io/library/notebook-controller_v1.8.0_22.04_1_amd64:rock (sha256:1e86d447e96a45b3be184d8a67179c47251b25ba647e75f04f8496e1ff31986e)...done
unpacking docker.io/library/notebook-controller_v1.8.0_22.04_1_amd64:v1.8.0_22.04_1 (sha256:02e2a7c184869d576c26c322b3a3958a2d9695ca4c731a38c82ff93fd4b5b716)...done
integration run-test: commands[4] | tox -c charm_repo -e controller-integration
WARNING: test command found but not installed in testenv
  cmd: /usr/bin/tox
  env: /home/ubuntu/kubeflow-rocks/notebook-controller/.tox/integration
Maybe you forgot to specify a dependency? See also the whitelist_externals envconfig setting.

DEPRECATION WARNING: this will be an error in tox 4 and above!
controller-integration create: /home/ubuntu/kubeflow-rocks/notebook-controller/charm_repo/.tox/controller-integration
controller-integration run-test-pre: PYTHONHASHSEED='4133218327'
controller-integration run-test: commands[0] | tox -c charms/jupyter-controller -e integration
WARNING: test command found but not installed in testenv
  cmd: /usr/bin/tox
  env: /home/ubuntu/kubeflow-rocks/notebook-controller/charm_repo/.tox/controller-integration
Maybe you forgot to specify a dependency? See also the whitelist_externals envconfig setting.

DEPRECATION WARNING: this will be an error in tox 4 and above!
integration create: /home/ubuntu/kubeflow-rocks/notebook-controller/charm_repo/charms/jupyter-controller/.tox/integration
integration installdeps: -rrequirements-integration.txt
integration installed: anyio==4.0.0,asttokens==2.4.0,backcall==0.2.0,bcrypt==4.0.1,cachetools==5.3.1,certifi==2023.7.22,cffi==1.15.1,charset-normalizer==3.2.0,cryptography==41.0.3,decorator==5.1.1,exceptiongroup==1.1.3,executing==1.2.0,google-auth==2.22.0,h11==0.14.0,httpcore==0.17.3,httpx==0.24.1,hvac==1.2.0,idna==3.4,iniconfig==2.0.0,ipdb==0.13.13,ipython==8.12.2,jedi==0.19.0,Jinja2==3.1.2,juju==3.2.2,kubernetes==27.2.0,lightkube==0.14.0,lightkube-models==1.28.1.4,macaroonbakery==1.3.1,MarkupSafe==2.1.3,matplotlib-inline==0.1.6,mypy-extensions==1.0.0,oauthlib==3.2.2,packaging==23.1,paramiko==2.12.0,parso==0.8.3,pexpect==4.8.0,pickleshare==0.7.5,pluggy==1.3.0,prompt-toolkit==3.0.39,protobuf==3.20.3,ptyprocess==0.7.0,pure-eval==0.2.2,pyasn1==0.5.0,pyasn1-modules==0.3.0,pycparser==2.21,Pygments==2.16.1,pyhcl==0.4.5,pymacaroons==0.13.0,PyNaCl==1.5.0,pyRFC3339==1.1,pytest==7.4.2,pytest-asyncio==0.21.1,pytest-operator==0.29.0,python-dateutil==2.8.2,pytz==2023.3.post1,PyYAML==6.0.1,requests==2.31.0,requests-oauthlib==1.3.1,rsa==4.9,six==1.16.0,sniffio==1.3.0,stack-data==0.6.2,tenacity==8.2.3,tomli==2.0.1,toposort==1.10,traitlets==5.9.0,typing-extensions==4.7.1,typing-inspect==0.9.0,urllib3==1.26.16,wcwidth==0.2.6,websocket-client==1.6.2,websockets==8.1
integration run-test-pre: PYTHONHASHSEED='72743770'
integration run-test: commands[0] | pytest -v --tb native --asyncio-mode=auto /home/ubuntu/kubeflow-rocks/notebook-controller/charm_repo/charms/jupyter-controller/tests/integration --log-cli-level=INFO -s
======================================================================= test session starts ========================================================================
platform linux -- Python 3.8.10, pytest-7.4.2, pluggy-1.3.0 -- /home/ubuntu/kubeflow-rocks/notebook-controller/charm_repo/charms/jupyter-controller/.tox/integration/bin/python
cachedir: .tox/integration/.pytest_cache
rootdir: /home/ubuntu/kubeflow-rocks/notebook-controller/charm_repo/charms/jupyter-controller
configfile: pyproject.toml
plugins: anyio-4.0.0, asyncio-0.21.1, operator-0.29.0
asyncio: mode=auto
collected 4 items                                                                                                                                                  

tests/integration/test_charm.py::test_build_and_deploy 
-------------------------------------------------------------------------- live log setup --------------------------------------------------------------------------
INFO     pytest_operator.plugin:plugin.py:647 Adding model microk8s-localhost:test-charm-tge1 on cloud microk8s
-------------------------------------------------------------------------- live log call ---------------------------------------------------------------------------
INFO     juju.model:model.py:2069 Deploying ch:amd64/focal/istio-pilot-647
INFO     juju.model:model.py:2069 Deploying ch:amd64/focal/istio-gateway-648
WARNING  juju.model:model.py:1558 relate is deprecated and will be removed. Use integrate instead.
INFO     juju.model:model.py:2759 Waiting for model:
  istio-pilot/0 [allocating] waiting: installing agent
  istio-ingressgateway/0 [allocating] waiting: installing agent
INFO     juju.model:model.py:2759 Waiting for model:
  istio-pilot/0 [executing] maintenance: Deploying Istio control plane
  istio-ingressgateway/0 [executing] maintenance: installing charm software
INFO     juju.model:model.py:2759 Waiting for model:
  istio-pilot/0 [idle] active: 
  istio-ingressgateway/0 [idle] active: 
INFO     juju.model:model.py:2069 Deploying ch:amd64/focal/jupyter-ui-21
WARNING  juju.model:model.py:1558 relate is deprecated and will be removed. Use integrate instead.
INFO     pytest_operator.plugin:plugin.py:526 Using tmp_path: /home/ubuntu/kubeflow-rocks/notebook-controller/charm_repo/charms/jupyter-controller/.tox/integration/tmp/pytest/test-charm-tge10
INFO     pytest_operator.plugin:plugin.py:975 Building charm jupyter-controller
INFO     pytest_operator.plugin:plugin.py:980 Built charm jupyter-controller in 50.77s
INFO     juju.model:model.py:2069 Deploying local:jupyter-controller-0
INFO     juju.model:model.py:2759 Waiting for model:
  istio-pilot/0 [idle] active: 
  istio-ingressgateway/0 [idle] active: 
  jupyter-ui/0 [idle] active: 
  jupyter-controller/0 [allocating] waiting: installing agent
INFO     juju.model:model.py:2759 Waiting for model:
  jupyter-controller/0 [executing] maintenance: Creating K8S resources
PASSED
tests/integration/test_charm.py::test_prometheus_integration 
-------------------------------------------------------------------------- live log call ---------------------------------------------------------------------------
INFO     juju.model:model.py:2069 Deploying ch:amd64/focal/prometheus-scrape-config-k8s-39
WARNING  juju.model:model.py:1558 relate is deprecated and will be removed. Use integrate instead.
WARNING  juju.model:model.py:1558 relate is deprecated and will be removed. Use integrate instead.
INFO     juju.model:model.py:2759 Waiting for model:
  istio-pilot/0 [idle] active: 
  istio-ingressgateway/0 [idle] active: 
  jupyter-ui/0 [idle] active: 
  jupyter-controller/0 [executing] active: 
  prometheus-k8s/0 [allocating] waiting: installing agent
  prometheus-scrape-config-k8s/0 [allocating] waiting: installing agent
INFO     juju.model:model.py:2759 Waiting for model:
  jupyter-controller/0 [idle] active: 
  prometheus-k8s/0 [allocating] waiting: agent initialising
  prometheus-scrape-config-k8s/0 [idle] active: 
INFO     juju.model:model.py:2759 Waiting for model:
  prometheus-k8s/0 [executing] maintenance: installing charm software
INFO     juju.model:model.py:2759 Waiting for model:
  prometheus-k8s/0 [executing] active: 
INFO     test_charm:test_charm.py:94 Prometheus available at http://10.1.199.251:9090
INFO     test_charm:test_charm.py:97 Testing prometheus deployment (attempt 1)
INFO     test_charm:test_charm.py:105 Response status is success
INFO     test_charm:test_charm.py:115 Testing prometheus targets (attempt 1)
INFO     test_charm:test_charm.py:121 Response status is success
INFO     test_charm:test_charm.py:130 Testing prometheus rules (attempt 1)
INFO     test_charm:test_charm.py:136 Response status is success
PASSED
tests/integration/test_charm.py::test_create_notebook 
-------------------------------------------------------------------------- live log call ---------------------------------------------------------------------------
INFO     httpx:_client.py:1013 HTTP Request: GET https://172.31.18.195:16443/api/v1/namespaces/test-charm-tge1 "HTTP/1.1 200 OK"
INFO     httpx:_client.py:1013 HTTP Request: PATCH https://172.31.18.195:16443/api/v1/namespaces/test-charm-tge1 "HTTP/1.1 200 OK"
INFO     httpx:_client.py:1013 HTTP Request: POST https://172.31.18.195:16443/apis/kubeflow.org/v1/namespaces/test-charm-tge1/notebooks "HTTP/1.1 201 Created"
INFO     httpx:_client.py:1013 HTTP Request: GET https://172.31.18.195:16443/apis/kubeflow.org/v1/namespaces/test-charm-tge1/notebooks/sample-notebook "HTTP/1.1 200 OK"
INFO     httpx:_client.py:1013 HTTP Request: GET https://172.31.18.195:16443/apis/kubeflow.org/v1/namespaces/test-charm-tge1/notebooks/sample-notebook "HTTP/1.1 200 OK"
INFO     test_charm:test_charm.py:196 notebook/sample-notebook readyReplicas == None (waiting for '1')
INFO     httpx:_client.py:1013 HTTP Request: GET https://172.31.18.195:16443/apis/kubeflow.org/v1/namespaces/test-charm-tge1/notebooks/sample-notebook "HTTP/1.1 200 OK"
INFO     test_charm:test_charm.py:194 notebook/sample-notebook readyReplicas == 1
PASSED
tests/integration/test_charm.py::test_remove_with_resources_present 
-------------------------------------------------------------------------- live log call ---------------------------------------------------------------------------
INFO     httpx:_client.py:1013 HTTP Request: GET https://172.31.18.195:16443/apis/apiextensions.k8s.io/v1/customresourcedefinitions?labelSelector=app.juju.is/created-by%3Djupyter-controller "HTTP/1.1 200 OK"
INFO     httpx:_client.py:1013 HTTP Request: GET https://172.31.18.195:16443/api/v1/namespaces/test-charm-tge1/services/jupyter-controller "HTTP/1.1 404 Not Found"
INFO     httpx:_client.py:1013 HTTP Request: GET https://172.31.18.195:16443/apis/kubeflow.org/v1/namespaces/test-charm-tge1/notebooks/sample-notebook "HTTP/1.1 404 Not Found"
PASSED
------------------------------------------------------------------------ live log teardown -------------------------------------------------------------------------
INFO     pytest_operator.plugin:plugin.py:783 Model status:

Model            Controller          Cloud/Region        Version  SLA          Timestamp
test-charm-tge1  microk8s-localhost  microk8s/localhost  3.1.5    unsupported  14:42:37Z

App                           Version                Status  Scale  Charm                         Channel        Rev  Address         Exposed  Message
istio-ingressgateway                                 active      1  istio-gateway                 latest/edge    648  10.152.183.209  no       
istio-pilot                                          active      1  istio-pilot                   latest/edge    647  10.152.183.40   no       
jupyter-ui                    res:oci-image@5536a2d  active      1  jupyter-ui                    latest/stable   21  10.152.183.69   no       
prometheus-k8s                2.46.0                 active      1  prometheus-k8s                latest/edge    137  10.152.183.180  no       
prometheus-scrape-config-k8s  n/a                    active      1  prometheus-scrape-config-k8s  latest/stable   39  10.152.183.74   no       

Unit                             Workload  Agent  Address       Ports     Message
istio-ingressgateway/0*          active    idle   10.1.199.209            
istio-pilot/0*                   active    idle   10.1.199.212            
jupyter-ui/0*                    active    idle   10.1.199.238  5000/TCP  
prometheus-k8s/0*                active    idle   10.1.199.251            
prometheus-scrape-config-k8s/0*  active    idle   10.1.199.228            

INFO     pytest_operator.plugin:plugin.py:789 Juju error logs:

unit-prometheus-k8s-0: 14:41:02 ERROR unit.prometheus-k8s/0.juju-log no relation on tracing: tracing not ready
unit-prometheus-k8s-0: 14:41:05 ERROR unit.prometheus-k8s/0.juju-log prometheus-peers:2: no relation on tracing: tracing not ready
unit-prometheus-k8s-0: 14:41:06 ERROR unit.prometheus-k8s/0.juju-log metrics-endpoint:4: no relation on tracing: tracing not ready
unit-prometheus-k8s-0: 14:41:08 ERROR unit.prometheus-k8s/0.juju-log no relation on tracing: tracing not ready
unit-prometheus-k8s-0: 14:41:10 ERROR unit.prometheus-k8s/0.juju-log no relation on tracing: tracing not ready
unit-prometheus-k8s-0: 14:41:12 ERROR unit.prometheus-k8s/0.juju-log no relation on tracing: tracing not ready
unit-prometheus-k8s-0: 14:41:14 ERROR unit.prometheus-k8s/0.juju-log no relation on tracing: tracing not ready
unit-prometheus-k8s-0: 14:41:43 ERROR unit.prometheus-k8s/0.juju-log no relation on tracing: tracing not ready
unit-prometheus-k8s-0: 14:41:48 ERROR unit.prometheus-k8s/0.juju-log no relation on tracing: tracing not ready
unit-prometheus-k8s-0: 14:41:50 ERROR unit.prometheus-k8s/0.juju-log no relation on tracing: tracing not ready
unit-prometheus-k8s-0: 14:41:53 ERROR unit.prometheus-k8s/0.juju-log metrics-endpoint:4: no relation on tracing: tracing not ready
unit-prometheus-k8s-0: 14:41:57 ERROR unit.prometheus-k8s/0.juju-log metrics-endpoint:4: no relation on tracing: tracing not ready
unit-prometheus-k8s-0: 14:41:59 ERROR unit.prometheus-k8s/0.juju-log metrics-endpoint:4: no relation on tracing: tracing not ready
unit-prometheus-k8s-0: 14:42:21 ERROR unit.prometheus-k8s/0.juju-log metrics-endpoint:4: no relation on tracing: tracing not ready

INFO     pytest_operator.plugin:plugin.py:877 Resetting model test-charm-tge1...
INFO     pytest_operator.plugin:plugin.py:866    Destroying applications istio-pilot
INFO     pytest_operator.plugin:plugin.py:866    Destroying applications istio-ingressgateway
INFO     pytest_operator.plugin:plugin.py:866    Destroying applications jupyter-ui
INFO     pytest_operator.plugin:plugin.py:866    Destroying applications prometheus-k8s
INFO     pytest_operator.plugin:plugin.py:866    Destroying applications prometheus-scrape-config-k8s
INFO     pytest_operator.plugin:plugin.py:882 Not waiting on reset to complete.
INFO     pytest_operator.plugin:plugin.py:855 Forgetting main...


========================================================================= warnings summary =========================================================================
tests/integration/test_charm.py::test_build_and_deploy
tests/integration/test_charm.py::test_build_and_deploy
tests/integration/test_charm.py::test_prometheus_integration
tests/integration/test_charm.py::test_prometheus_integration
  /home/ubuntu/kubeflow-rocks/notebook-controller/charm_repo/charms/jupyter-controller/.tox/integration/lib/python3.8/site-packages/juju/model.py:1558: DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
    log.warn("relate is deprecated and will be removed. Use integrate instead.")

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================================================ 4 passed, 4 warnings in 350.61s (0:05:50) =============================================================
_____________________________________________________________________________ summary ______________________________________________________________________________
  integration: commands succeeded
  congratulations :)
_____________________________________________________________________________ summary ______________________________________________________________________________
  controller-integration: commands succeeded
  congratulations :)
_____________________________________________________________________________ summary ______________________________________________________________________________
  integration: commands succeeded
  congratulations :)
```

</details>
