### PR TITLE
feat: update jupyter-web-app rock for 1.8

### DIFF
--- a/jupyter-web-app/rockcraft.yaml
+++ b/jupyter-web-app/rockcraft.yaml
@@ -4,7 +4,7 @@ summary: An image for Jupyter UI
 description: |
   This image is used as part of Charmed Kubeflow product. Jupyter UI web application provides
   users with web UI to access and manipulate Jupyter Notebooks in Charmed Kubeflow.
-version: v1.7.0_20.04_1 # version format: <KF-upstream-version>_<base-version>_<ROCK-version>
+version: v1.8.0_20.04_1 # version format: <KF-upstream-version>_<base-version>_<ROCK-version>
 license: Apache-2.0
 base: ubuntu:20.04
 run-user: _daemon_
@@ -24,7 +24,7 @@ parts:
     plugin: nil
     source: https://github.com/kubeflow/kubeflow
     source-type: git
-    source-tag: v1.7-branch  # upstream branch
+    source-tag: v1.8-branch  # upstream branch
     source-depth: 1
     build-packages:
       - python3-venv
@@ -40,7 +40,7 @@ parts:
     plugin: nil
     source: https://github.com/kubeflow/kubeflow
     source-type: git
-    source-tag: v1.7-branch  # upstream branch
+    source-tag: v1.8-branch  # upstream branch
     source-depth: 1
     build-snaps:
       - node/12/stable
@@ -57,7 +57,7 @@ parts:
     plugin: nil
     source: https://github.com/kubeflow/kubeflow
     source-type: git
-    source-tag: v1.7-branch  # upstream branch
+    source-tag: v1.8-branch  # upstream branch
     source-depth: 1
     build-snaps:
       - node/12/stable
@@ -75,7 +75,7 @@ parts:
     plugin: nil
     source: https://github.com/kubeflow/kubeflow
     source-type: git
-    source-tag: v1.7-branch  # upstream branch
+    source-tag: v1.8-branch  # upstream branch
     source-depth: 1
     build-packages:
       - python3-venv
@@ -92,7 +92,7 @@ parts:
   gunicorn:
     plugin: python
     source: https://github.com/kubeflow/kubeflow.git
-    source-tag: v1.7-branch  # upstream branch
+    source-tag: v1.8-branch  # upstream branch
     source-depth: 1
     python-requirements:
     - components/crud-web-apps/jupyter/backend/requirements.txt

--- a/jupyter-web-app/tox.ini
+++ b/jupyter-web-app/tox.ini
@@ -1,0 +1,45 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+[tox]
+skipsdist = True
+skip_missing_interpreters = True
+
+[testenv]
+setenv =
+    PYTHONPATH={toxinidir}
+    PYTHONBREAKPOINT=ipdb.set_trace
+    CHARM_REPO=https://github.com/canonical/notebook-operators.git
+    CHARM_BRANCH=main
+    LOCAL_CHARM_DIR=charm_repo
+
+
+[testenv:integration]
+passenv = *
+allowlist_externals =
+    bash
+    git
+    rm
+    tox
+    rockcraft
+deps =
+    juju<4.0
+    pytest
+    pytest-operator
+    ops
+commands =
+    # build and pack rock
+    rockcraft pack
+    # clone related charm
+    rm -rf {env:LOCAL_CHARM_DIR}
+    git clone --branch {env:CHARM_BRANCH} {env:CHARM_REPO} {env:LOCAL_CHARM_DIR}
+    # upload rock to docker and microk8s cache, replace charm's container with local rock reference
+    bash -c 'NAME=$(yq eval .name rockcraft.yaml) && \
+             VERSION=$(yq eval .version rockcraft.yaml) && \
+             ARCH=$(yq eval -r ".platforms | keys" rockcraft.yaml | cut -d" " -f2) && \
+             ROCK="$\{NAME\}_$\{VERSION\}_$\{ARCH\}" && \
+             sudo skopeo --insecure-policy copy oci-archive:$ROCK.rock docker-daemon:$ROCK:$VERSION && \
+             docker save $ROCK > $ROCK.tar && \
+             microk8s ctr image import $ROCK.tar && \
+             yq e -i ".resources.oci-image.upstream-source=\"$ROCK:$VERSION\"" {env:LOCAL_CHARM_DIR}/charms/jupyter-ui/metadata.yaml'
+    # run charm integration test with rock
+    tox -c {env:LOCAL_CHARM_DIR} -e ui-integration


### PR DESCRIPTION
Update the `jupyter-web-app` rock for 1.8, based on the [upstream image](https://github.com/kubeflow/kubeflow/blob/v1.8-branch/components/crud-web-apps/jupyter/Dockerfile) 

## Summary of changes
- add tox.ini with charm integration tests
- change the branch to `v1.8-branch`
- bump the rock version to 1.8
- pin pyjuju to <4.0 in the test requirements due to migration to juju 3 in 1.8

## Testing
Run the charm integration tests
<details>
<summary>Test logs</summary>

```bash
tox -e integration
integration create: /home/ubuntu/kubeflow-rocks/jupyter-web-app/.tox/integration
integration installdeps: juju<4.0, pytest, pytest-operator, ops
integration installed: asttokens==2.4.0,backcall==0.2.0,bcrypt==4.0.1,cachetools==5.3.1,certifi==2023.7.22,cffi==1.15.1,charset-normalizer==3.2.0,cryptography==41.0.4,decorator==5.1.1,exceptiongroup==1.1.3,executing==1.2.0,google-auth==2.23.0,hvac==1.2.1,idna==3.4,iniconfig==2.0.0,ipdb==0.13.13,ipython==8.12.2,jedi==0.19.0,Jinja2==3.1.2,juju==3.2.2,kubernetes==28.1.0,macaroonbakery==1.3.1,MarkupSafe==2.1.3,matplotlib-inline==0.1.6,mypy-extensions==1.0.0,oauthlib==3.2.2,ops==2.6.0,packaging==23.1,paramiko==2.12.0,parso==0.8.3,pexpect==4.8.0,pickleshare==0.7.5,pluggy==1.3.0,prompt-toolkit==3.0.39,protobuf==3.20.3,ptyprocess==0.7.0,pure-eval==0.2.2,pyasn1==0.5.0,pyasn1-modules==0.3.0,pycparser==2.21,Pygments==2.16.1,pyhcl==0.4.5,pymacaroons==0.13.0,PyNaCl==1.5.0,pyRFC3339==1.1,pytest==7.4.2,pytest-asyncio==0.21.1,pytest-operator==0.29.0,python-dateutil==2.8.2,pytz==2023.3.post1,PyYAML==6.0.1,requests==2.31.0,requests-oauthlib==1.3.1,rsa==4.9,six==1.16.0,stack-data==0.6.2,tomli==2.0.1,toposort==1.10,traitlets==5.10.0,typing-extensions==4.8.0,typing-inspect==0.9.0,urllib3==1.26.16,wcwidth==0.2.6,websocket-client==1.6.3,websockets==8.1
integration run-test-pre: PYTHONHASHSEED='3418795615'
integration run-test: commands[0] | rockcraft pack
WARNING: test command found but not installed in testenv
  cmd: /snap/bin/rockcraft
  env: /home/ubuntu/kubeflow-rocks/jupyter-web-app/.tox/integration
Maybe you forgot to specify a dependency? See also the whitelist_externals envconfig setting.

DEPRECATION WARNING: this will be an error in tox 4 and above!
Retrieved base ubuntu:20.04 for amd64                                                                                                                              
Extracted ubuntu:20.04                                                                                                                                             
Executed: pull backend                                                                                                                                             
Executed: pull frontend-lib                                                                                                                                        
Executed: pull frontend                                                                                                                                            
Executed: pull gunicorn                                                                                                                                            
Executed: pull pebble                                                                                                                                              
Executed: pull security-team-requirement                                                                                                                           
Executed: pull webapp                                                                                                                                              
Executed: overlay backend                                                                                                                                          
Executed: overlay frontend-lib                                                                                                                                     
Executed: overlay frontend                                                                                                                                         
Executed: overlay gunicorn                                                                                                                                         
Executed: overlay pebble                                                                                                                                           
Executed: overlay security-team-requirement                                                                                                                        
Executed: overlay webapp                                                                                                                                           
Executed: build backend                                                                                                                                            
Executed: build frontend-lib                                                                                                                                       
Executed: skip pull frontend-lib (already ran)                                                                                                                     
Executed: skip overlay frontend-lib (already ran)                                                                                                                  
Executed: skip build frontend-lib (already ran)                                                                                                                    
Executed: stage frontend-lib (required to build 'frontend')                                                                                                        
Executed: build frontend                                                                                                                                           
Executed: build gunicorn                                                                                                                                           
Executed: build pebble                                                                                                                                             
Executed: build security-team-requirement                                                                                                                          
Executed: skip pull backend (already ran)                                                                                                                          
Executed: skip overlay backend (already ran)                                                                                                                       
Executed: skip build backend (already ran)                                                                                                                         
Executed: stage backend (required to build 'webapp')                                                                                                               
Executed: skip pull frontend (already ran)                                                                                                                         
Executed: skip overlay frontend (already ran)                                                                                                                      
Executed: skip build frontend (already ran)                                                                                                                        
Executed: stage frontend (required to build 'webapp')                                                                                                              
Executed: build webapp                                                                                                                                             
Executed: skip stage backend (already ran)                                                                                                                         
Executed: skip stage frontend-lib (already ran)                                                                                                                    
Executed: skip stage frontend (already ran)                                                                                                                        
Executed: stage gunicorn                                                                                                                                           
Executed: stage pebble                                                                                                                                             
Executed: stage security-team-requirement                                                                                                                          
Executed: stage webapp                                                                                                                                             
Executed: prime backend                                                                                                                                            
Executed: prime frontend-lib                                                                                                                                       
Executed: prime frontend                                                                                                                                           
Executed: prime gunicorn                                                                                                                                           
Executed: prime pebble                                                                                                                                             
Executed: prime security-team-requirement                                                                                                                          
Executed: prime webapp                                                                                                                                             
Executed parts lifecycle                                                                                                                                           
Exported to OCI archive 'jupyter-web-app_v1.8.0_20.04_1_amd64.rock'                                                                                                
integration run-test: commands[1] | rm -rf charm_repo
WARNING: test command found but not installed in testenv
  cmd: /usr/bin/rm
  env: /home/ubuntu/kubeflow-rocks/jupyter-web-app/.tox/integration
Maybe you forgot to specify a dependency? See also the whitelist_externals envconfig setting.

DEPRECATION WARNING: this will be an error in tox 4 and above!
integration run-test: commands[2] | git clone --branch main https://github.com/canonical/notebook-operators.git charm_repo
WARNING: test command found but not installed in testenv
  cmd: /usr/bin/git
  env: /home/ubuntu/kubeflow-rocks/jupyter-web-app/.tox/integration
Maybe you forgot to specify a dependency? See also the whitelist_externals envconfig setting.

DEPRECATION WARNING: this will be an error in tox 4 and above!
Cloning into 'charm_repo'...
remote: Enumerating objects: 4172, done.
remote: Counting objects: 100% (709/709), done.
remote: Compressing objects: 100% (285/285), done.
remote: Total 4172 (delta 523), reused 529 (delta 413), pack-reused 3463
Receiving objects: 100% (4172/4172), 1.58 MiB | 12.71 MiB/s, done.
Resolving deltas: 100% (1973/1973), done.
integration run-test: commands[3] | bash -c 'NAME=$(yq eval .name rockcraft.yaml) &&  VERSION=$(yq eval .version rockcraft.yaml) &&  ARCH=$(yq eval -r ".platforms | keys" rockcraft.yaml | cut -d" " -f2) &&  ROCK="${NAME}_${VERSION}_${ARCH}" &&  sudo /snap/rockcraft/current/bin/skopeo --insecure-policy copy oci-archive:$ROCK.rock docker-daemon:$ROCK:$VERSION &&  docker save $ROCK > $ROCK.tar &&  microk8s ctr image import $ROCK.tar && yq e -i ".resources.oci-image.upstream-source=\"$ROCK:$VERSION\"" charm_repo/charms/jupyter-ui/metadata.yaml'
WARNING: test command found but not installed in testenv
  cmd: /usr/bin/bash
  env: /home/ubuntu/kubeflow-rocks/jupyter-web-app/.tox/integration
Maybe you forgot to specify a dependency? See also the whitelist_externals envconfig setting.

DEPRECATION WARNING: this will be an error in tox 4 and above!
Getting image source signatures
Copying blob edaedc954fb5 done  
Copying blob 21b37d182222 done  
Copying blob bccc444e2b1d done  
Copying blob 3be0312946c5 done  
Copying blob 24922ce30499 done  
Copying config 07e34851ad done  
Writing manifest to image destination
Storing signatures
unpacking docker.io/library/jupyter-web-app_v1.8.0_20.04_1_amd64:v1.8.0_20.04_1 (sha256:6aec47abe612d9e4025c83118d2359f42c0363e55be274094271d4761dced9c4)...done
integration run-test: commands[4] | tox -c charm_repo -e ui-integration
WARNING: test command found but not installed in testenv
  cmd: /usr/bin/tox
  env: /home/ubuntu/kubeflow-rocks/jupyter-web-app/.tox/integration
Maybe you forgot to specify a dependency? See also the whitelist_externals envconfig setting.

DEPRECATION WARNING: this will be an error in tox 4 and above!
ui-integration create: /home/ubuntu/kubeflow-rocks/jupyter-web-app/charm_repo/.tox/ui-integration
ui-integration run-test-pre: PYTHONHASHSEED='728895837'
ui-integration run-test: commands[0] | tox -c charms/jupyter-ui -e integration
WARNING: test command found but not installed in testenv
  cmd: /usr/bin/tox
  env: /home/ubuntu/kubeflow-rocks/jupyter-web-app/charm_repo/.tox/ui-integration
Maybe you forgot to specify a dependency? See also the whitelist_externals envconfig setting.

DEPRECATION WARNING: this will be an error in tox 4 and above!
integration create: /home/ubuntu/kubeflow-rocks/jupyter-web-app/charm_repo/charms/jupyter-ui/.tox/integration
integration installdeps: -rrequirements-integration.txt
integration installed: aiohttp==3.8.5,aiosignal==1.3.1,asttokens==2.4.0,async-timeout==4.0.3,attrs==23.1.0,backcall==0.2.0,bcrypt==4.0.1,cachetools==5.3.1,certifi==2023.7.22,cffi==1.15.1,charset-normalizer==3.2.0,cryptography==41.0.3,decorator==5.1.1,exceptiongroup==1.1.3,executing==1.2.0,frozenlist==1.4.0,google-auth==2.22.0,hvac==1.2.0,idna==3.4,iniconfig==2.0.0,ipdb==0.13.13,ipython==8.12.2,jedi==0.19.0,Jinja2==3.1.2,juju==3.2.2,kubernetes==27.2.0,macaroonbakery==1.3.1,MarkupSafe==2.1.3,matplotlib-inline==0.1.6,multidict==6.0.4,mypy-extensions==1.0.0,oauthlib==3.2.2,packaging==23.1,paramiko==2.12.0,parso==0.8.3,pexpect==4.8.0,pickleshare==0.7.5,pluggy==1.3.0,prompt-toolkit==3.0.39,protobuf==3.20.3,ptyprocess==0.7.0,pure-eval==0.2.2,pyasn1==0.5.0,pyasn1-modules==0.3.0,pycparser==2.21,Pygments==2.16.1,pyhcl==0.4.5,pymacaroons==0.13.0,PyNaCl==1.5.0,pyRFC3339==1.1,pytest==7.4.2,pytest-asyncio==0.21.1,pytest-operator==0.29.0,python-dateutil==2.8.2,pytz==2023.3.post1,PyYAML==6.0.1,requests==2.31.0,requests-oauthlib==1.3.1,rsa==4.9,six==1.16.0,stack-data==0.6.2,tomli==2.0.1,toposort==1.10,traitlets==5.9.0,typing-extensions==4.7.1,typing-inspect==0.9.0,urllib3==1.26.16,wcwidth==0.2.6,websocket-client==1.6.2,websockets==8.1,yarl==1.9.2
integration run-test-pre: PYTHONHASHSEED='4125875946'
integration run-test: commands[0] | pytest -v --tb native --asyncio-mode=auto /home/ubuntu/kubeflow-rocks/jupyter-web-app/charm_repo/charms/jupyter-ui/tests/integration --log-cli-level=INFO -s
======================================================================= test session starts ========================================================================
platform linux -- Python 3.8.10, pytest-7.4.2, pluggy-1.3.0 -- /home/ubuntu/kubeflow-rocks/jupyter-web-app/charm_repo/charms/jupyter-ui/.tox/integration/bin/python
cachedir: .tox/integration/.pytest_cache
rootdir: /home/ubuntu/kubeflow-rocks/jupyter-web-app/charm_repo/charms/jupyter-ui
configfile: pyproject.toml
plugins: asyncio-0.21.1, operator-0.29.0
asyncio: mode=auto
collected 5 items                                                                                                                                                  

tests/integration/test_charm.py::test_build_and_deploy 
-------------------------------------------------------------------------- live log setup --------------------------------------------------------------------------
INFO     pytest_operator.plugin:plugin.py:647 Adding model microk8s-localhost:test-charm-rnmn on cloud microk8s
-------------------------------------------------------------------------- live log call ---------------------------------------------------------------------------
INFO     pytest_operator.plugin:plugin.py:526 Using tmp_path: /home/ubuntu/kubeflow-rocks/jupyter-web-app/charm_repo/charms/jupyter-ui/.tox/integration/tmp/pytest/test-charm-rnmn0
INFO     pytest_operator.plugin:plugin.py:975 Building charm jupyter-ui
INFO     pytest_operator.plugin:plugin.py:980 Built charm jupyter-ui in 380.78s
INFO     juju.model:model.py:2069 Deploying local:jupyter-ui-0
INFO     juju.model:model.py:2759 Waiting for model:
  jupyter-ui/0 [allocating] waiting: installing agent
INFO     juju.model:model.py:2759 Waiting for model:
  jupyter-ui/0 [executing] active: 
INFO     juju.model:model.py:2759 Waiting for model:
  jupyter-ui/0 [idle] active: 
PASSED
tests/integration/test_charm.py::test_ui_is_accessible PASSED
tests/integration/test_charm.py::test_notebook_image_selector[jupyter-images-expected_images0-image] 
-------------------------------------------------------------------------- live log call ---------------------------------------------------------------------------
INFO     juju.model:model.py:2759 Waiting for model:
  jupyter-ui/0 [idle] active: 
INFO     juju.model:model.py:2759 Waiting for model:
  jupyter-ui/0 [idle] active: 
PASSED
tests/integration/test_charm.py::test_notebook_image_selector[vscode-images-expected_images1-imageGroupOne] 
-------------------------------------------------------------------------- live log call ---------------------------------------------------------------------------
INFO     juju.model:model.py:2759 Waiting for model:
  jupyter-ui/0 [idle] active: 
INFO     juju.model:model.py:2759 Waiting for model:
  jupyter-ui/0 [idle] active: 
PASSED
tests/integration/test_charm.py::test_notebook_image_selector[rstudio-images-expected_images2-imageGroupTwo] 
-------------------------------------------------------------------------- live log call ---------------------------------------------------------------------------
INFO     juju.model:model.py:2759 Waiting for model:
  jupyter-ui/0 [idle] active: 
INFO     juju.model:model.py:2759 Waiting for model:
  jupyter-ui/0 [idle] active: 
PASSED
------------------------------------------------------------------------ live log teardown -------------------------------------------------------------------------
INFO     pytest_operator.plugin:plugin.py:783 Model status:

Model            Controller          Cloud/Region        Version  SLA          Timestamp
test-charm-rnmn  microk8s-localhost  microk8s/localhost  3.1.5    unsupported  16:22:44Z

App         Version  Status  Scale  Charm       Channel  Rev  Address         Exposed  Message
jupyter-ui           active      1  jupyter-ui             0  10.152.183.197  no       

Unit           Workload  Agent  Address       Ports  Message
jupyter-ui/0*  active    idle   10.1.199.199         

INFO     pytest_operator.plugin:plugin.py:789 Juju error logs:


INFO     pytest_operator.plugin:plugin.py:877 Resetting model test-charm-rnmn...
INFO     pytest_operator.plugin:plugin.py:866    Destroying applications jupyter-ui
INFO     pytest_operator.plugin:plugin.py:882 Not waiting on reset to complete.
INFO     pytest_operator.plugin:plugin.py:855 Forgetting main...


================================================================== 5 passed in 580.70s (0:09:40) ===================================================================
_____________________________________________________________________________ summary ______________________________________________________________________________
  integration: commands succeeded
  congratulations :)
_____________________________________________________________________________ summary ______________________________________________________________________________
  ui-integration: commands succeeded
  congratulations :)
_____________________________________________________________________________ summary ______________________________________________________________________________
  integration: commands succeeded
  congratulations :)
```

</details>