### PR TITLE
fix: update command and env variables

### DIFF
--- a/jupyter-pytorch-cuda-full/rockcraft.yaml
+++ b/jupyter-pytorch-cuda-full/rockcraft.yaml
@@ -19,8 +19,9 @@ services:
     environment:
        NB_USER: jovyan
        NB_UID: 1001
-       NB_PREFIX: /
-       HOME: /home/jovyan
+       # the following environment variables need to be present in the Pod environment
+       #HOME: ""
+       #NB_PREFIX: ""
        SHELL: /bin/bash
        LANG: en_US.UTF-8
        LANGUAGE: en_US.UTF-8
@@ -30,7 +31,7 @@ services:
        NVIDIA_DRIVER_CAPABILITIES: compute,utility
        LD_LIBRARY_PATH: /usr/local/nvidia/lib:/usr/local/nvidia/lib64
        PYTHONPATH: /opt/conda/lib/python3.8/site-packages/
-    command: ./jupyter lab --notebook-dir="/home/jovyan" --ip=0.0.0.0 --no-browser --allow-root --port=8888 --ServerApp.token="" --ServerApp.password="" --ServerApp.allow_origin="*" --ServerApp.base_url="/" --ServerApp.authenticate_prometheus=False
+    command: bash -c './jupyter lab --notebook-dir=${HOME} --ip=0.0.0.0 --no-browser --port=8888 --ServerApp.token="" --ServerApp.password="" --ServerApp.allow_origin="*" --ServerApp.base_url=${NB_PREFIX} --ServerApp.authenticate_prometheus=False'
     working-dir: /opt/conda/bin/
 platforms:
   amd64:

--- a/jupyter-pytorch-cuda-full/rockcraft.yaml
+++ b/jupyter-pytorch-cuda-full/rockcraft.yaml
@@ -19,7 +19,7 @@ services:
     environment:
        NB_USER: jovyan
        NB_UID: 1001
-       # the following environment variables need to be present in the Pod environment
+       # The following environment variables need to be specified in the Pod's environment, and not hardcoded.
        #HOME: ""
        #NB_PREFIX: ""
        SHELL: /bin/bash

--- a/jupyter-pytorch-full/rockcraft.yaml
+++ b/jupyter-pytorch-full/rockcraft.yaml
@@ -19,15 +19,16 @@ services:
     environment:
        NB_USER: jovyan
        NB_UID: 1001
-       NB_PREFIX: /
-       HOME: /home/jovyan
+       # the following environment variables need to be present in the Pod environment
+       #HOME: ""
+       #NB_PREFIX: ""
        SHELL: /bin/bash
        LANG: en_US.UTF-8
        LANGUAGE: en_US.UTF-8
        LC_ALL: en_US.UTF-8
        PATH: /opt/conda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
        PYTHONPATH: /opt/conda/lib/python3.8/site-packages/
-    command: ./jupyter lab --notebook-dir="/home/jovyan" --ip=0.0.0.0 --no-browser --port=8888 --ServerApp.token="" --ServerApp.password="" --ServerApp.allow_origin="*" --ServerApp.base_url="/" --ServerApp.authenticate_prometheus="False"
+    command: bash -c './jupyter lab --notebook-dir=${HOME} --ip=0.0.0.0 --no-browser --port=8888 --ServerApp.token="" --ServerApp.password="" --ServerApp.allow_origin="*" --ServerApp.base_url=${NB_PREFIX} --ServerApp.authenticate_prometheus=False'
     working-dir: /opt/conda/bin/
 platforms:
   amd64:

--- a/jupyter-pytorch-full/rockcraft.yaml
+++ b/jupyter-pytorch-full/rockcraft.yaml
@@ -19,7 +19,7 @@ services:
     environment:
        NB_USER: jovyan
        NB_UID: 1001
-       # the following environment variables need to be present in the Pod environment
+       # The following environment variables need to be specified in the Pod's environment, and not hardcoded.
        #HOME: ""
        #NB_PREFIX: ""
        SHELL: /bin/bash

--- a/jupyter-scipy/rockcraft.yaml
+++ b/jupyter-scipy/rockcraft.yaml
@@ -19,15 +19,16 @@ services:
     environment:
       NB_USER: jovyan
       NB_UID: 1001
-      NB_PREFIX: /
-      HOME: /home/jovyan
+      # the following environment variables need to be present in the Pod environment
+      #HOME: ""
+      #NB_PREFIX: ""
       SHELL: /bin/bash
       LANG: en_US.UTF-8
       LANGUAGE: en_US.UTF-8
       LC_ALL: en_US.UTF-8
       PATH: /opt/conda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
       PYTHONPATH: /opt/conda/lib/python3.8/site-packages/
-    command: ./jupyter lab --notebook-dir="/home/jovyan" --ip=0.0.0.0 --no-browser --port=8888 --ServerApp.token="" --ServerApp.password="" --ServerApp.allow_origin="*" --ServerApp.base_url="/" --ServerApp.authenticate_prometheus=False
+    command: bash -c './jupyter lab --notebook-dir=${HOME} --ip=0.0.0.0 --no-browser --port=8888 --ServerApp.token="" --ServerApp.password="" --ServerApp.allow_origin="*" --ServerApp.base_url=${NB_PREFIX} --ServerApp.authenticate_prometheus=False'
     working-dir: /opt/conda/bin/
 platforms:
   amd64:

--- a/jupyter-scipy/rockcraft.yaml
+++ b/jupyter-scipy/rockcraft.yaml
@@ -19,7 +19,7 @@ services:
     environment:
       NB_USER: jovyan
       NB_UID: 1001
-      # the following environment variables need to be present in the Pod environment
+      # The following environment variables need to be specified in the Pod's environment, and not hardcoded.
       #HOME: ""
       #NB_PREFIX: ""
       SHELL: /bin/bash

--- a/jupyter-tensorflow-cuda-full/rockcraft.yaml
+++ b/jupyter-tensorflow-cuda-full/rockcraft.yaml
@@ -2,7 +2,7 @@
 # https://github.com/kubeflow/kubeflow/blob/v1.7-branch/components/example-notebook-servers/base/Dockerfile
 # https://github.com/kubeflow/kubeflow/blob/v1.7-branch/components/example-notebook-servers/jupyter/Dockerfile
 # https://github.com/kubeflow/kubeflow/blob/v1.7-branch/components/example-notebook-servers/jupyter-tensorflow-full/cuda.Dockerfile
-name: jupyter-tensorflow-cude-full
+name: jupyter-tensorflow-cuda-full
 summary: An image for using Jupyter & Tensorflow on GPUs
 description: |
   This image is used as part of the Charmed Kubeflow product. It is deployed
@@ -23,15 +23,16 @@ services:
     environment:
       NB_USER: jovyan
       NB_UID: 1001
-      NB_PREFIX: /
-      HOME: /home/jovyan
+      # the following environment variables need to be present in the Pod environment
+      #HOME: ""
+      #NB_PREFIX: ""
       SHELL: /bin/bash
       LANG: en_US.UTF-8
       LANGUAGE: en_US.UTF-8
       LC_ALL: en_US.UTF-8
       PATH: /opt/conda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
       PYTHONPATH: /opt/conda/lib/python3.8/site-packages/
-    command: ./jupyter lab --notebook-dir="/home/jovyan" --ip=0.0.0.0 --no-browser --port=8888 --ServerApp.token="" --ServerApp.password="" --ServerApp.allow_origin="*" --ServerApp.base_url="/" --ServerApp.authenticate_prometheus=False
+    command: bash -c './jupyter lab --notebook-dir=${HOME} --ip=0.0.0.0 --no-browser --port=8888 --ServerApp.token="" --ServerApp.password="" --ServerApp.allow_origin="*" --ServerApp.base_url=${NB_PREFIX} --ServerApp.authenticate_prometheus=False'
     working-dir: /opt/conda/bin/
 platforms:
   amd64:

--- a/jupyter-tensorflow-cuda-full/rockcraft.yaml
+++ b/jupyter-tensorflow-cuda-full/rockcraft.yaml
@@ -23,7 +23,7 @@ services:
     environment:
       NB_USER: jovyan
       NB_UID: 1001
-      # the following environment variables need to be present in the Pod environment
+      # The following environment variables need to be specified in the Pod's environment, and not hardcoded.
       #HOME: ""
       #NB_PREFIX: ""
       SHELL: /bin/bash

--- a/jupyter-tensorflow-full/rockcraft.yaml
+++ b/jupyter-tensorflow-full/rockcraft.yaml
@@ -23,15 +23,16 @@ services:
     environment:
       NB_USER: jovyan
       NB_UID: 1001
-      NB_PREFIX: /
-      HOME: /home/jovyan
+      # the following environment variables need to be present in the Pod environment
+      #HOME: ""
+      #NB_PREFIX: ""
       SHELL: /bin/bash
       LANG: en_US.UTF-8
       LANGUAGE: en_US.UTF-8
       LC_ALL: en_US.UTF-8
       PATH: /opt/conda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
       PYTHONPATH: /opt/conda/lib/python3.8/site-packages/
-    command: ./jupyter lab --notebook-dir="/home/jovyan" --ip=0.0.0.0 --no-browser --port=8888 --ServerApp.token="" --ServerApp.password="" --ServerApp.allow_origin="*" --ServerApp.base_url="/" --ServerApp.authenticate_prometheus=False
+    command: bash -c './jupyter lab --notebook-dir=${HOME} --ip=0.0.0.0 --no-browser --port=8888 --ServerApp.token="" --ServerApp.password="" --ServerApp.allow_origin="*" --ServerApp.base_url=${NB_PREFIX} --ServerApp.authenticate_prometheus=False'
     working-dir: /opt/conda/bin/
 platforms:
   amd64:

--- a/jupyter-tensorflow-full/rockcraft.yaml
+++ b/jupyter-tensorflow-full/rockcraft.yaml
@@ -23,7 +23,7 @@ services:
     environment:
       NB_USER: jovyan
       NB_UID: 1001
-      # the following environment variables need to be present in the Pod environment
+      # The following environment variables need to be specified in the Pod's environment, and not hardcoded.
       #HOME: ""
       #NB_PREFIX: ""
       SHELL: /bin/bash


### PR DESCRIPTION
# Description
Jupyter notebook ROCK are not functionining properly because environment variables are not used in the command AND are set in environment for the service.

More details in: https://github.com/canonical/kubeflow-rocks/issues/54

Summary of changes:
- Updated environments in all Jupyter notebook server ROCKs to omit envirtonmen variables that need to be set in the Pod environment. Added comment indicating this.
- Updated command to expand environment variables.