### PR TITLE
fix: update rocks for 1.8

### DIFF
--- a/jupyter-pytorch-cuda-full/rockcraft.yaml
+++ b/jupyter-pytorch-cuda-full/rockcraft.yaml
@@ -19,8 +19,9 @@ services:
     environment:
        NB_USER: jovyan
        NB_UID: 1001
-       NB_PREFIX: /
-       HOME: /home/jovyan
+       # The following environment variables need to be specified in the Pod's environment, and not hardcoded.
+       #HOME: ""
+       #NB_PREFIX: ""
        SHELL: /bin/bash
        LANG: en_US.UTF-8
        LANGUAGE: en_US.UTF-8
@@ -30,7 +31,7 @@ services:
        NVIDIA_DRIVER_CAPABILITIES: compute,utility
        LD_LIBRARY_PATH: /usr/local/nvidia/lib:/usr/local/nvidia/lib64
        PYTHONPATH: /opt/conda/lib/python3.8/site-packages/
-    command: ./jupyter lab --notebook-dir="/home/jovyan" --ip=0.0.0.0 --no-browser --allow-root --port=8888 --ServerApp.token="" --ServerApp.password="" --ServerApp.allow_origin="*" --ServerApp.base_url="/" --ServerApp.authenticate_prometheus=False
+    command: bash -c './jupyter lab --notebook-dir=${HOME} --ip=0.0.0.0 --no-browser --port=8888 --ServerApp.token="" --ServerApp.password="" --ServerApp.allow_origin="*" --ServerApp.base_url=${NB_PREFIX} --ServerApp.authenticate_prometheus=False'
     working-dir: /opt/conda/bin/
 platforms:
   amd64:

--- a/jupyter-pytorch-cuda-full/tests/test_access.py
+++ b/jupyter-pytorch-cuda-full/tests/test_access.py
@@ -32,11 +32,18 @@ def main():
     LOCAL_ROCK_IMAGE = f"{rock_image}:{rock_version}"
     
     print(f"Running {LOCAL_ROCK_IMAGE}")
-    container_id = subprocess.run(["docker", "run", "-d", "-p", "8888:8888", LOCAL_ROCK_IMAGE], stdout=subprocess.PIPE).stdout.decode('utf-8')
+    NB_PREFIX_DIR="test"
+    container_id = subprocess.run(["docker", "run", "-d", "-p", "8888:8888", "-e", f"NB_PREFIX={NB_PREFIX_DIR}", LOCAL_ROCK_IMAGE], stdout=subprocess.PIPE).stdout.decode('utf-8')
     container_id = container_id[0:12]
 
-    # Try to reach the notebook server
-    output = check_notebook_server_up("http://0.0.0.0:8888/lab")
+    # to ensure container is started
+    time.sleep(5)
+
+    # retrieve notebook server URL
+    output = subprocess.run(["curl", f"http://127.0.0.1:8888/{NB_PREFIX_DIR}/lab"], stdout=subprocess.PIPE).stdout.decode('utf-8')
+
+    # retrieve logs
+    logs = subprocess.run(["docker", "logs", f"{container_id}"], stdout=subprocess.PIPE).stdout.decode('utf-8')
 
     # cleanup
     subprocess.run(["docker", "stop", f"{container_id}"])
@@ -44,6 +51,10 @@ def main():
 
     # test output
     assert "JupyterLab" in output
+
+    # test logs
+    assert "Jupyter Server" in logs
+    assert f"http://127.0.0.1:8888/{NB_PREFIX_DIR}/lab" in logs
 
 
 if __name__ == "__main__":

--- a/jupyter-pytorch-cuda-full/tox.ini
+++ b/jupyter-pytorch-cuda-full/tox.ini
@@ -12,7 +12,7 @@ setenv =
     CHARM_BRANCH=main
     LOCAL_CHARM_DIR=charm_repo
 
-[testenv:unit]
+[testenv:sanity]
 passenv = *
 allowlist_externals =
     bash

--- a/jupyter-pytorch-full/rockcraft.yaml
+++ b/jupyter-pytorch-full/rockcraft.yaml
@@ -19,15 +19,16 @@ services:
     environment:
        NB_USER: jovyan
        NB_UID: 1001
-       NB_PREFIX: /
-       HOME: /home/jovyan
+       # The following environment variables need to be specified in the Pod's environment, and not hardcoded.
+       #HOME: ""
+       #NB_PREFIX: ""
        SHELL: /bin/bash
        LANG: en_US.UTF-8
        LANGUAGE: en_US.UTF-8
        LC_ALL: en_US.UTF-8
        PATH: /opt/conda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
        PYTHONPATH: /opt/conda/lib/python3.8/site-packages/
-    command: ./jupyter lab --notebook-dir="/home/jovyan" --ip=0.0.0.0 --no-browser --port=8888 --ServerApp.token="" --ServerApp.password="" --ServerApp.allow_origin="*" --ServerApp.base_url="/" --ServerApp.authenticate_prometheus="False"
+    command: bash -c './jupyter lab --notebook-dir=${HOME} --ip=0.0.0.0 --no-browser --port=8888 --ServerApp.token="" --ServerApp.password="" --ServerApp.allow_origin="*" --ServerApp.base_url=${NB_PREFIX} --ServerApp.authenticate_prometheus=False'
     working-dir: /opt/conda/bin/
 platforms:
   amd64:

--- a/jupyter-pytorch-full/tests/test_access.py
+++ b/jupyter-pytorch-full/tests/test_access.py
@@ -32,11 +32,18 @@ def main():
     LOCAL_ROCK_IMAGE = f"{rock_image}:{rock_version}"
     
     print(f"Running {LOCAL_ROCK_IMAGE}")
-    container_id = subprocess.run(["docker", "run", "-d", "-p", "8888:8888", LOCAL_ROCK_IMAGE], stdout=subprocess.PIPE).stdout.decode('utf-8')
+    NB_PREFIX_DIR="test"
+    container_id = subprocess.run(["docker", "run", "-d", "-p", "8888:8888", "-e", f"NB_PREFIX={NB_PREFIX_DIR}", LOCAL_ROCK_IMAGE], stdout=subprocess.PIPE).stdout.decode('utf-8')
     container_id = container_id[0:12]
 
-    # Try to reach the notebook server
-    output = check_notebook_server_up("http://0.0.0.0:8888/lab")
+    # to ensure container is started
+    time.sleep(5)
+
+    # retrieve notebook server URL
+    output = subprocess.run(["curl", f"http://127.0.0.1:8888/{NB_PREFIX_DIR}/lab"], stdout=subprocess.PIPE).stdout.decode('utf-8')
+
+    # retrieve logs
+    logs = subprocess.run(["docker", "logs", f"{container_id}"], stdout=subprocess.PIPE).stdout.decode('utf-8')
 
     # cleanup
     subprocess.run(["docker", "stop", f"{container_id}"])
@@ -44,6 +51,10 @@ def main():
 
     # test output
     assert "JupyterLab" in output
+
+    # test logs
+    assert "Jupyter Server" in logs
+    assert f"http://127.0.0.1:8888/{NB_PREFIX_DIR}/lab" in logs
 
 
 if __name__ == "__main__":

--- a/jupyter-pytorch-full/tox.ini
+++ b/jupyter-pytorch-full/tox.ini
@@ -12,7 +12,7 @@ setenv =
     CHARM_BRANCH=main
     LOCAL_CHARM_DIR=charm_repo
 
-[testenv:unit]
+[testenv:sanity]
 passenv = *
 allowlist_externals =
     bash

--- a/jupyter-scipy/rockcraft.yaml
+++ b/jupyter-scipy/rockcraft.yaml
@@ -19,15 +19,16 @@ services:
     environment:
       NB_USER: jovyan
       NB_UID: 1001
-      NB_PREFIX: /
-      HOME: /home/jovyan
+      # The following environment variables need to be specified in the Pod's environment, and not hardcoded.
+      #HOME: ""
+      #NB_PREFIX: ""
       SHELL: /bin/bash
       LANG: en_US.UTF-8
       LANGUAGE: en_US.UTF-8
       LC_ALL: en_US.UTF-8
       PATH: /opt/conda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
       PYTHONPATH: /opt/conda/lib/python3.8/site-packages/
-    command: ./jupyter lab --notebook-dir="/home/jovyan" --ip=0.0.0.0 --no-browser --port=8888 --ServerApp.token="" --ServerApp.password="" --ServerApp.allow_origin="*" --ServerApp.base_url="/" --ServerApp.authenticate_prometheus=False
+    command: bash -c './jupyter lab --notebook-dir=${HOME} --ip=0.0.0.0 --no-browser --port=8888 --ServerApp.token="" --ServerApp.password="" --ServerApp.allow_origin="*" --ServerApp.base_url=${NB_PREFIX} --ServerApp.authenticate_prometheus=False'
     working-dir: /opt/conda/bin/
 platforms:
   amd64:

--- a/jupyter-scipy/tests/test_access.py
+++ b/jupyter-scipy/tests/test_access.py
@@ -32,11 +32,18 @@ def main():
     LOCAL_ROCK_IMAGE = f"{rock_image}:{rock_version}"
     
     print(f"Running {LOCAL_ROCK_IMAGE}")
-    container_id = subprocess.run(["docker", "run", "-d", "-p", "8888:8888", LOCAL_ROCK_IMAGE], stdout=subprocess.PIPE).stdout.decode('utf-8')
+    NB_PREFIX_DIR="test"
+    container_id = subprocess.run(["docker", "run", "-d", "-p", "8888:8888", "-e", f"NB_PREFIX={NB_PREFIX_DIR}", LOCAL_ROCK_IMAGE], stdout=subprocess.PIPE).stdout.decode('utf-8')
     container_id = container_id[0:12]
 
-    # Try to reach the notebook server
-    output = check_notebook_server_up("http://0.0.0.0:8888/lab")
+    # to ensure container is started
+    time.sleep(5)
+
+    # retrieve notebook server URL
+    output = subprocess.run(["curl", f"http://127.0.0.1:8888/{NB_PREFIX_DIR}/lab"], stdout=subprocess.PIPE).stdout.decode('utf-8')
+
+    # retrieve logs
+    logs = subprocess.run(["docker", "logs", f"{container_id}"], stdout=subprocess.PIPE).stdout.decode('utf-8')
 
     # cleanup
     subprocess.run(["docker", "stop", f"{container_id}"])
@@ -44,6 +51,10 @@ def main():
 
     # test output
     assert "JupyterLab" in output
+
+    # test logs
+    assert "Jupyter Server" in logs
+    assert f"http://127.0.0.1:8888/{NB_PREFIX_DIR}/lab" in logs
 
 
 if __name__ == "__main__":

--- a/jupyter-scipy/tox.ini
+++ b/jupyter-scipy/tox.ini
@@ -12,7 +12,7 @@ setenv =
     CHARM_BRANCH=main
     LOCAL_CHARM_DIR=charm_repo
 
-[testenv:unit]
+[testenv:sanity]
 passenv = *
 allowlist_externals =
     bash

--- a/jupyter-tensorflow-cuda-full/rockcraft.yaml
+++ b/jupyter-tensorflow-cuda-full/rockcraft.yaml
@@ -2,7 +2,7 @@
 # https://github.com/kubeflow/kubeflow/blob/v1.8-branch/components/example-notebook-servers/base/Dockerfile
 # https://github.com/kubeflow/kubeflow/blob/v1.8-branch/components/example-notebook-servers/jupyter/Dockerfile
 # https://github.com/kubeflow/kubeflow/blob/v1.8-branch/components/example-notebook-servers/jupyter-tensorflow-full/cuda.Dockerfile
-name: jupyter-tensorflow-cude-full
+name: jupyter-tensorflow-cuda-full
 summary: An image for using Jupyter & Tensorflow on GPUs
 description: |
   This image is used as part of the Charmed Kubeflow product. It is deployed

--- a/jupyter-tensorflow-cuda-full/rockcraft.yaml
+++ b/jupyter-tensorflow-cuda-full/rockcraft.yaml
@@ -1,7 +1,7 @@
 # Based on the following Dockerfiles:
-# https://github.com/kubeflow/kubeflow/blob/v1.7-branch/components/example-notebook-servers/base/Dockerfile
-# https://github.com/kubeflow/kubeflow/blob/v1.7-branch/components/example-notebook-servers/jupyter/Dockerfile
-# https://github.com/kubeflow/kubeflow/blob/v1.7-branch/components/example-notebook-servers/jupyter-tensorflow-full/cuda.Dockerfile
+# https://github.com/kubeflow/kubeflow/blob/v1.8-branch/components/example-notebook-servers/base/Dockerfile
+# https://github.com/kubeflow/kubeflow/blob/v1.8-branch/components/example-notebook-servers/jupyter/Dockerfile
+# https://github.com/kubeflow/kubeflow/blob/v1.8-branch/components/example-notebook-servers/jupyter-tensorflow-full/cuda.Dockerfile
 name: jupyter-tensorflow-cude-full
 summary: An image for using Jupyter & Tensorflow on GPUs
 description: |
@@ -11,7 +11,7 @@ description: |
 
   Both Tensorflow and Jupyter are installed in Conda environment, which is
   automatically activated.
-version: v1.7.0_20.04_1
+version: v1.8.0_20.04_1
 license: Apache-2.0
 base: ubuntu:20.04
 run-user: _daemon_
@@ -22,8 +22,9 @@ services:
     startup: enabled
     environment:
       NB_USER: jovyan
-      NB_UID: 1001
-      NB_PREFIX: /
+      # The following environment variables need to be specified in the Pod's environment, and not hardcoded.
+      #HOME: ""
+      #NB_PREFIX: ""
       HOME: /home/jovyan
       SHELL: /bin/bash
       LANG: en_US.UTF-8
@@ -31,7 +32,7 @@ services:
       LC_ALL: en_US.UTF-8
       PATH: /opt/conda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
       PYTHONPATH: /opt/conda/lib/python3.8/site-packages/
-    command: ./jupyter lab --notebook-dir="/home/jovyan" --ip=0.0.0.0 --no-browser --port=8888 --ServerApp.token="" --ServerApp.password="" --ServerApp.allow_origin="*" --ServerApp.base_url="/" --ServerApp.authenticate_prometheus=False
+    command: bash -c './jupyter lab --notebook-dir=${HOME} --ip=0.0.0.0 --no-browser --port=8888 --ServerApp.token="" --ServerApp.password="" --ServerApp.allow_origin="*" --ServerApp.base_url=${NB_PREFIX} --ServerApp.authenticate_prometheus=False'
     working-dir: /opt/conda/bin/
 platforms:
   amd64:
@@ -94,7 +95,7 @@ parts:
     plugin: nil
     source: https://github.com/kubeflow/kubeflow
     source-type: git
-    source-tag: v1.7-branch # upstream branch
+    source-tag: v1.8-branch # upstream branch
     build-packages:
       - curl
       - lsb-release

--- a/jupyter-tensorflow-full/rockcraft.yaml
+++ b/jupyter-tensorflow-full/rockcraft.yaml
@@ -1,7 +1,7 @@
 # Based on the following Dockerfiles:
-# https://github.com/kubeflow/kubeflow/blob/v1.7-branch/components/example-notebook-servers/base/Dockerfile
-# https://github.com/kubeflow/kubeflow/blob/v1.7-branch/components/example-notebook-servers/jupyter/Dockerfile
-# https://github.com/kubeflow/kubeflow/blob/v1.7-branch/components/example-notebook-servers/jupyter-tensorflow-full/cpu.Dockerfile
+# https://github.com/kubeflow/kubeflow/blob/v1.8-branch/components/example-notebook-servers/base/Dockerfile
+# https://github.com/kubeflow/kubeflow/blob/v1.8-branch/components/example-notebook-servers/jupyter/Dockerfile
+# https://github.com/kubeflow/kubeflow/blob/v1.8-branch/components/example-notebook-servers/jupyter-tensorflow-full/cpu.Dockerfile
 name: jupyter-tensorflow-full
 summary: An image for using Jupyter & Tensorflow on CPUs
 description: |
@@ -11,7 +11,7 @@ description: |
 
   Both Tensorflow and Jupyter are installed in Conda environment, which is
   automatically activated.
-version: v1.7.0_20.04_1
+version: v1.8.0_20.04_1
 license: Apache-2.0
 base: ubuntu:20.04
 run-user: _daemon_
@@ -23,15 +23,16 @@ services:
     environment:
       NB_USER: jovyan
       NB_UID: 1001
-      NB_PREFIX: /
-      HOME: /home/jovyan
+      # The following environment variables need to be specified in the Pod's environment, and not hardcoded.
+      #HOME: ""
+      #NB_PREFIX: ""
       SHELL: /bin/bash
       LANG: en_US.UTF-8
       LANGUAGE: en_US.UTF-8
       LC_ALL: en_US.UTF-8
       PATH: /opt/conda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
       PYTHONPATH: /opt/conda/lib/python3.8/site-packages/
-    command: ./jupyter lab --notebook-dir="/home/jovyan" --ip=0.0.0.0 --no-browser --port=8888 --ServerApp.token="" --ServerApp.password="" --ServerApp.allow_origin="*" --ServerApp.base_url="/" --ServerApp.authenticate_prometheus=False
+    command: bash -c './jupyter lab --notebook-dir=${HOME} --ip=0.0.0.0 --no-browser --port=8888 --ServerApp.token="" --ServerApp.password="" --ServerApp.allow_origin="*" --ServerApp.base_url=${NB_PREFIX} --ServerApp.authenticate_prometheus=False'
     working-dir: /opt/conda/bin/
 platforms:
   amd64:


### PR DESCRIPTION
# Description

This PR is for https://github.com/canonical/kubeflow-rocks/issues/54 and cherry-picks https://github.com/canonical/kubeflow-rocks/pull/55
Required updates for ROCK for 1.8

Summary of changes:
- Updated service command to use env vars.
- Added comment on usage of env vars.
- Updated sanity tests to use env vars.

<details><summary>Sample sanity test on `jupyter-scipy` ROCK:</summary>


```
$ tox -e sanity
sanity: commands[0]> rockcraft pack
Retrieved base ubuntu:20.04 for amd64                                                                                         
Extracted ubuntu:20.04                      
Executed: skip pull conda-jupyter (already ran)                                          
Executed: skip pull generate-locale (already ran)                                        
Executed: skip pull kubectl (already ran)   
Executed: skip pull nodejs (already ran)    
Executed: skip pull non-root-user (already ran)                                          
Executed: skip pull overlay-pkgs (already ran)                                           
Executed: skip pull pebble (already ran)    
Executed: skip pull security-team-requirement (already ran)                              
Executed: skip overlay conda-jupyter (already ran)                                       
Executed: skip overlay generate-locale (already ran)                                     
Executed: skip overlay kubectl (already ran)
Executed: skip overlay nodejs (already ran) 
Executed: skip overlay non-root-user (already ran)                                       
Executed: skip overlay overlay-pkgs (already ran)                                        
Executed: skip overlay pebble (already ran) 
Executed: skip overlay security-team-requirement (already ran)                           
Executed: skip build conda-jupyter (already ran)                                         
Executed: skip build generate-locale (already ran)                                       
Executed: skip build kubectl (already ran)  
Executed: skip build nodejs (already ran)   
Executed: skip build non-root-user (already ran)                                         
Executed: skip build overlay-pkgs (already ran)                                          
Executed: skip build pebble (already ran)   
Executed: skip build security-team-requirement (already ran)                             
Executed: skip stage conda-jupyter (already ran)                                         
Executed: skip stage generate-locale (already ran)                                       
Executed: skip stage kubectl (already ran)  
Executed: skip stage nodejs (already ran)   
Executed: skip stage non-root-user (already ran)                                         
Executed: skip stage overlay-pkgs (already ran)                                          
Executed: skip stage pebble (already ran)   
Executed: skip stage security-team-requirement (already ran)                             
Executed: skip prime conda-jupyter (already ran)                                         
Executed: skip prime generate-locale (already ran)                                       
Executed: skip prime kubectl (already ran)  
Executed: skip prime nodejs (already ran)   
Executed: skip prime non-root-user (already ran)                                         
Executed: skip prime overlay-pkgs (already ran)                                          
Executed: skip prime pebble (already ran)   
Executed: skip prime security-team-requirement (already ran)                             
Executed parts lifecycle                    
Exported to OCI archive 'jupyter-scipy_v1.8.0_20.04_1_amd64.rock'                        
sanity: commands[1]> bash -c 'NAME=$(yq eval .name rockcraft.yaml) && VERSION=$(yq eval .version rockcraft.yaml) && ARCH=$(yq eval -r ".platforms | keys" rockcraft.yaml | cut -d" " -f2) ROCK="${NAME}_${VERSION}_${ARCH}" && sudo skopeo --insecure-policy copy oci-archive:$ROCK.rock docker-daemon:$ROCK:$VERSION && docker save $ROCK > $ROCK.tar'
Getting image source signatures
Copying blob 96d54c3075c9 done
Copying blob 10f031486a87 done
Copying blob c63838066321 done
Copying blob 6db45539ac8f done
Copying blob 6675d763c1ca done
Copying config e134a8c941 done
Writing manifest to image destination
Storing signatures
sanity: commands[2]> pytest -v --tb native --show-capture=all --log-cli-level=INFO /home/ubuntu/rocks/kubeflow-rocks/jupyter-scipy/tests
===================================================== test session starts =====================================================
platform linux -- Python 3.8.10, pytest-7.4.2, pluggy-1.3.0 -- /home/ubuntu/rocks/kubeflow-rocks/jupyter-scipy/.tox/sanity/bin/python
cachedir: .tox/sanity/.pytest_cache
rootdir: /home/ubuntu/rocks/kubeflow-rocks/jupyter-scipy
plugins: anyio-4.0.0, asyncio-0.21.1, operator-0.29.0
asyncio: mode=strict
collected 1 item                                                                                                              

tests/test_rock.py::test_rock 
------------------------------------------------------- live log setup --------------------------------------------------------
INFO     pytest_operator.plugin:plugin.py:647 Adding model microk8s-localhost:test-rock-oocd on cloud microk8s
PASSED                                                                                                                  [100%]
------------------------------------------------------ live log teardown ------------------------------------------------------
INFO     pytest_operator.plugin:plugin.py:783 Model status:

Model           Controller          Cloud/Region        Version  SLA          Timestamp
test-rock-oocd  microk8s-localhost  microk8s/localhost  3.1.6    unsupported  12:18:13-04:00

INFO     pytest_operator.plugin:plugin.py:789 Juju error logs:


INFO     pytest_operator.plugin:plugin.py:877 Resetting model test-rock-oocd...
INFO     pytest_operator.plugin:plugin.py:882 Not waiting on reset to complete.
INFO     pytest_operator.plugin:plugin.py:855 Forgetting main...


===================================================== 1 passed in 10.31s ======================================================
sanity: commands[3]> python /home/ubuntu/rocks/kubeflow-rocks/jupyter-scipy/tests/test_imports.py
Running command in jupyter-scipy_v1.8.0_20.04_1_amd64:v1.8.0_20.04_1
2023-10-11T16:18:19.877Z [pebble] Started daemon.
2023-10-11T16:18:19.885Z [pebble] POST /v1/exec 8.435917ms 202
2023-10-11T16:18:19.893Z [pebble] GET /v1/tasks/1/websocket/control 7.084606ms 200
2023-10-11T16:18:19.893Z [pebble] GET /v1/tasks/1/websocket/stdio 43.376µs 200
2023-10-11T16:18:19.893Z [pebble] GET /v1/tasks/1/websocket/stderr 60.853µs 200
2023-10-11T16:18:19.902Z [pebble] POST /v1/exec 7.144743ms 202
2023-10-11T16:18:19.911Z [pebble] GET /v1/tasks/2/websocket/control 7.952588ms 200
2023-10-11T16:18:19.911Z [pebble] GET /v1/tasks/2/websocket/stdio 52.207µs 200
2023-10-11T16:18:19.911Z [pebble] GET /v1/tasks/2/websocket/stderr 124.59µs 200
/opt/conda/lib/python3.8/site-packages/azure/storage/blob/_deserialization.py:641: SyntaxWarning: "is" with a literal. Did you mean "=="?
  elif num_empty_lines is 2:
/opt/conda/lib/python3.8/site-packages/azure/storage/blob/_serialization.py:189: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if requests is None or len(requests) is 0:
/opt/conda/lib/python3.8/site-packages/azure/storage/blob/_serialization.py:301: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  if len(serialized_query) is not 0:
/opt/conda/lib/python3.8/site-packages/azure/storage/blob/_upload_chunking.py:409: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if n is 0 or self._buffer.closed:
/opt/conda/lib/python3.8/site-packages/azure/storage/blob/baseblobservice.py:1071: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  if lease_duration is not -1 and \
/opt/conda/lib/python3.8/site-packages/azure/storage/blob/baseblobservice.py:2779: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  if lease_duration is not -1 and \
/opt/conda/lib/python3.8/site-packages/azure/storage/common/_connection.py:82: SyntaxWarning: "is" with a literal. Did you mean "=="?
  self.protocol = self.protocol if parsed_url.scheme is '' else parsed_url.scheme
/opt/conda/lib/python3.8/site-packages/azure/storage/blob/blockblobservice.py:608: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  while len(data) < count and len(data_chunk) is not 0:
[I 231011 16:18:23 utils:157] NumExpr defaulting to 4 threads.
[I 231011 16:18:25 font_manager:1443] generated new fontManager
2023-10-11T16:18:27.163Z [pebble] GET /v1/changes/2/wait 7.25122249s 200
2023-10-11T16:18:27.179Z [pebble] GET /v1/changes/1/wait 7.285290881s 200
sanity: commands[4]> python /home/ubuntu/rocks/kubeflow-rocks/jupyter-scipy/tests/test_access.py
Running jupyter-scipy_v1.8.0_20.04_1_amd64:v1.8.0_20.04_1
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  4033  100  4033    0     0   437k      0 --:--:-- --:--:-- --:--:--  437k
2023-10-11T16:18:28.014Z [pebble] Started daemon.
2023-10-11T16:18:28.022Z [pebble] POST /v1/services 7.99769ms 202
2023-10-11T16:18:28.023Z [pebble] Started default services with change 1.
2023-10-11T16:18:28.031Z [pebble] Service "jupyter" starting: bash -c './jupyter lab --notebook-dir=${HOME} --ip=0.0.0.0 --no-browser --port=8888 --ServerApp.token="" --ServerApp.password="" --ServerApp.allow_origin="*" --ServerApp.base_url=${NB_PREFIX} --ServerApp.authenticate_prometheus=False'
9666e43cbf3a
9666e43cbf3a
  sanity: OK (113.90=setup[0.39]+cmd[59.94,27.38,12.06,7.91,6.22] seconds)
  congratulations :) (113.95 seconds)
```

</details>