### PR TITLE
chore: update rockcraft project, add sanity test, and tox.ini file

### DIFF
--- a/centraldashboard/rockcraft.yaml
+++ b/centraldashboard/rockcraft.yaml
@@ -1,25 +1,33 @@
+# Dockerfile https://github.com/kubeflow/kubeflow/blob/v1.7-branch/components/centraldashboard/Dockerfile
 name: kubeflow-central-dashboard
 summary: Kubeflow Landing Page
 description: |
   This component serves as the landing page and central dashboard for Kubeflow deployments.
   It provides a jump-off point to all other facets of the platform.
-version: 1.7.0_22.04_1 # version format: <KF-upstream-version>_<base-version>_<Charmed-KF-version>
+version: "1.7"
 license: Apache-2.0
-base: ubuntu:22.04
-services:
-  serve:
-    override: replace
-    summary: "centraldashboard service"
-    command: "/usr/bin/npm start --prefix /app"
-    startup: enabled
-    user: ubuntu
-    environment:
-      NODE_ENV: production
+base: ubuntu@22.04
 platforms:
   amd64:
+run-user: _daemon_
+
+services:
+  serve:
+    override: merge
+    summary: "Kubeflow central dashboard service"
+    command: "/usr/bin/npm start --prefix /app"
+    startup: enabled
+    environment:
+      NODE_ENV: production
 
 parts:
-  centraldashboard:
+  security-team-requirement:
+    plugin: nil
+    override-build: |
+      mkdir -p ${CRAFT_PART_INSTALL}/usr/share/rocks
+      (echo "# os-release" && cat /etc/os-release && echo "# dpkg-query" && dpkg-query -f '${db:Status-Abbrev},${binary:Package},${Version},${source:Package},${Source:Version}\n' -W) > ${CRAFT_PART_INSTALL}/usr/share/rocks/dpkg.query
+
+  builder:
     plugin: dump
     source: https://github.com/kubeflow/kubeflow
     source-type: git
@@ -27,7 +35,6 @@ parts:
     build-snaps:
       - node/18/stable
     build-packages:
-      - apt
       - bash
       - chromium-browser
       - libnss3
@@ -41,44 +48,32 @@ parts:
       - CHROME_BIN: /usr/bin/chromium-browser
       - PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: true
     stage-packages:
-      - bash # this is for debugging only, should be removed for production
       - nodejs
       - npm
     override-build: |
       set -xe
-      cd $CRAFT_PART_SRC/components/centraldashboard/
+      cd ${CRAFT_PART_SRC}/components/centraldashboard/
 
       # set environment variables
       export BUILD_VERSION=$(git describe --abbrev=0 --tags)
       export BUILD_COMMIT=$(git rev-parse HEAD)
 
-      # build
+      # Build phase
+      # This rock only supports amd64 architecture at the moment, the application
+      # will be built w/o flags for other architectures for simplicity.
+      # Please refer to the upstream Dockerfile if that condition changes and different
+      # architectures need to be supported.
       npm rebuild && \
-      if [ "$(uname -m)" = "aarch64" ]; then \
-          export CFLAGS=-Wno-error && \
-          export CXXFLAGS=-Wno-error && \
-          npm install; \
-      else \
-          npm install; \
-      fi && \
+      npm install && \
       npm test && \
       npm run build && \
       npm prune --production
 
       # install build artifacts
-      mkdir -p $CRAFT_PART_INSTALL/app
-      cp -r * $CRAFT_PART_INSTALL/app
+      mkdir -p ${CRAFT_PART_INSTALL}/app
+      cp -r * ${CRAFT_PART_INSTALL}/app
 
-      # security requirement
-      mkdir -p ${CRAFT_PART_INSTALL}/usr/share/rocks
-      (echo "# os-release" && cat /etc/os-release && echo "# dpkg-query" && \
-       dpkg-query -f '${db:Status-Abbrev},${binary:Package},${Version},${source:Package},${Source:Version}\n' -W) \
-       > ${CRAFT_PART_INSTALL}/usr/share/rocks/dpkg.query
-
-  non-root-user:
-    plugin: nil
-    after: [centraldashboard]
-    overlay-script: |
-      # Create a user in the $CRAFT_OVERLAY chroot
-      groupadd -R $CRAFT_OVERLAY -g 1001 ubuntu
-      useradd -R $CRAFT_OVERLAY -M -r -u 1001 -g ubuntu ubuntu
+      # Change permissions of the /app directory to
+      # be owned by the _daemon_ user
+      chown 584792:584792 ${CRAFT_PART_INSTALL}/app
+      chmod 755 ${CRAFT_PART_INSTALL}/app

--- a/centraldashboard/rockcraft.yaml
+++ b/centraldashboard/rockcraft.yaml
@@ -1,10 +1,10 @@
-# Dockerfile https://github.com/kubeflow/kubeflow/blob/v1.7-branch/components/centraldashboard/Dockerfile
+# Dockerfile https://github.com/kubeflow/kubeflow/blob/v1.8-branch/components/centraldashboard/Dockerfile
 name: kubeflow-central-dashboard
 summary: Kubeflow Landing Page
 description: |
   This component serves as the landing page and central dashboard for Kubeflow deployments.
   It provides a jump-off point to all other facets of the platform.
-version: "1.7"
+version: "1.8"
 license: Apache-2.0
 base: ubuntu@22.04
 platforms:
@@ -13,7 +13,7 @@ run-user: _daemon_
 
 services:
   serve:
-    override: merge
+    override: replace
     summary: "Kubeflow central dashboard service"
     command: "/usr/bin/npm start --prefix /app"
     startup: enabled
@@ -30,10 +30,11 @@ parts:
   builder:
     plugin: dump
     source: https://github.com/kubeflow/kubeflow
+    source-subdir: components/centraldashboard
     source-type: git
-    source-tag: v1.7-branch # upstream branch
+    source-tag: v1.8-branch # upstream branch
     build-snaps:
-      - node/18/stable
+      - node/14/stable
     build-packages:
       - bash
       - chromium-browser
@@ -47,6 +48,7 @@ parts:
     build-environment:
       - CHROME_BIN: /usr/bin/chromium-browser
       - PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: true
+      - BUILD_VERSION: "1.8"
     stage-packages:
       - nodejs
       - npm
@@ -55,7 +57,6 @@ parts:
       cd ${CRAFT_PART_SRC}/components/centraldashboard/
 
       # set environment variables
-      export BUILD_VERSION=$(git describe --abbrev=0 --tags)
       export BUILD_COMMIT=$(git rev-parse HEAD)
 
       # Build phase
@@ -71,7 +72,7 @@ parts:
 
       # install build artifacts
       mkdir -p ${CRAFT_PART_INSTALL}/app
-      cp -r * ${CRAFT_PART_INSTALL}/app
+      cp -r ${CRAFT_PART_SRC}/components/centraldashboard/* ${CRAFT_PART_INSTALL}/app
 
       # Change permissions of the /app directory to
       # be owned by the _daemon_ user

--- a/centraldashboard/tests/test_rock.py
+++ b/centraldashboard/tests/test_rock.py
@@ -1,0 +1,55 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+#
+#
+
+from pathlib import Path
+
+import os
+import logging
+import random
+import pytest
+import string
+import subprocess
+import yaml
+
+from charmed_kubeflow_chisme.rock import CheckRock
+
+
+@pytest.fixture()
+def rock_test_env(tmpdir):
+    """Yields a temporary directory and random docker container name, then cleans them up after."""
+    container_name = "".join(
+        [str(i) for i in random.choices(string.ascii_lowercase, k=8)]
+    )
+    yield tmpdir, container_name
+
+    try:
+        subprocess.run(["docker", "rm", container_name])
+    except Exception:
+        pass
+    # tmpdir fixture we use here should clean up the other files for us
+
+
+@pytest.mark.abort_on_fail
+def test_rock(rock_test_env):
+    """Test rock."""
+    temp_dir, container_name = rock_test_env
+    check_rock = CheckRock("rockcraft.yaml")
+    rock_image = check_rock.get_name()
+    rock_version = check_rock.get_version()
+    LOCAL_ROCK_IMAGE = f"{rock_image}:{rock_version}"
+
+    # create ROCK filesystem
+    subprocess.run(
+        [
+            "docker",
+            "run",
+            LOCAL_ROCK_IMAGE,
+            "exec",
+            "ls",
+            "-la",
+            "/app",
+        ],
+        check=True,
+    )

--- a/centraldashboard/tox.ini
+++ b/centraldashboard/tox.ini
@@ -1,0 +1,61 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+[tox]
+skipsdist = True
+skip_missing_interpreters = True
+envlist = pack, export-to-docker, sanity, integration
+
+[testenv]
+setenv =
+    PYTHONPATH={toxinidir}
+    PYTHONBREAKPOINT=ipdb.set_trace
+
+[testenv:pack]
+passenv = *
+allowlist_externals =
+    rockcraft
+commands =
+    rockcraft pack
+
+[testenv:export-to-docker]
+passenv = *
+allowlist_externals =
+    bash
+    skopeo
+    yq
+commands =
+    # export already packed rock to docker
+    bash -c 'NAME=$(yq eval .name rockcraft.yaml) && \
+             VERSION=$(yq eval .version rockcraft.yaml) && \
+             ARCH=$(yq eval ".platforms | keys | .[0]" rockcraft.yaml) && \
+             ROCK="$\{NAME\}_$\{VERSION\}_$\{ARCH\}.rock" && \
+             DOCKER_IMAGE=$NAME:$VERSION && \\
+             echo "Exporting $ROCK to docker as $DOCKER_IMAGE" && \
+             skopeo --insecure-policy copy oci-archive:$ROCK docker-daemon:$DOCKER_IMAGE'
+
+[testenv:sanity]
+passenv = *
+deps =
+    pytest
+    charmed-kubeflow-chisme
+allowlist_externals =
+    echo
+commands =
+    # run rock tests
+    pytest -v --tb native --show-capture=all --log-cli-level=INFO {posargs} {toxinidir}/tests
+
+[testenv:integration]
+passenv = *
+allowlist_externals =
+    echo
+    bash
+    git
+    rm
+    tox
+deps =
+    juju<4.0
+    pytest
+    pytest-operator
+    ops
+commands =
+    echo "WARNING: This is a placeholder test - no test is implemented here."


### PR DESCRIPTION
This commit updates the rockcraft project to match the new requirements from the latest rockcraft version. It also refactors the security requirement to match the latest format in other rock repositories.
Bash is now removed from the image as it is not required and not recommended in production environments, and the build dependency on apt is also removed as it was not used at all. Adding sanity tests in this rock's repository and its corresponding tox file.

Fixes #71

#### Testing instructions

Prerequisites:
* skopeo
* docker

1. Build the rock `rockcraft pack -v`
2. Save the rock as an OCI image in docker's local registry `skopeo --insecure-policy copy oci-archive:kubeflow-central-dashboard_1.7_amd64.rock docker-daemon:cdash:0.1`
3. Run a container with the image and replace the entrypoint with a shell `docker run --rm -ti --entrypoint=/bin/sh cdash:0.1`
4. Ensure that:

* The `/app` directory exists
* The permissions of the `/app` directory are `drwxr-xr-x  11 _daemon_ _daemon_ 4.0K Feb  4 00:08 app`
* You can run the command `/usr/bin/npm start --prefix /app` and it outputs the following message:
```
Using Profiles service at http://localhost:8081/kfam
Server listening on port http://localhost:8082 (in development mode)
```