### PR TITLE
fix: remove prefix from command and set a working-dir to /app

### DIFF
--- a/centraldashboard/rockcraft.yaml
+++ b/centraldashboard/rockcraft.yaml
@@ -15,8 +15,9 @@ services:
   serve:
     override: replace
     summary: "Kubeflow central dashboard service"
-    command: "/usr/bin/npm start --prefix /app"
+    command: "/usr/bin/npm start"
     startup: enabled
+    working-dir: "/app"
     environment:
       NODE_ENV: production
 


### PR DESCRIPTION
In the past, this image used to pass --prefix /app to the npm start command, which is used to force non-global commands to run in the specified folder. We are removing that prefix and instead setting up a working-dir to keep consisdenty with upstream.

#### Testing instructions

Prerequisites:
* skopeo
* docker

1. Build the rock `rockcraft pack -v`
2. Save the rock as an OCI image in docker's local registry `skopeo --insecure-policy copy oci-archive:kubeflow-central-dashboard_1.8_amd64.rock docker-daemon:cdash:0.1`
3. Run a container with the image and replace the entrypoint with a shell `docker run --rm -ti cdash:0.1`
4. Ensure that the service is running correctly:

```
2024-02-14T13:26:52.268Z [serve] "other" is not a supported platform for Metrics
2024-02-14T13:26:52.268Z [serve] Using Profiles service at http://profiles-kfam.kubeflow:8081/kfam
2024-02-14T13:26:52.270Z [serve] Server listening on port http://localhost:8082 (in production mode)
```