### PR TITLE
refactor: use latest standards for the jupyter-web-app rock

### DIFF
--- a/jupyter-web-app/rockcraft.yaml
+++ b/jupyter-web-app/rockcraft.yaml
@@ -25,7 +25,7 @@ parts:
     plugin: nil
     source: https://github.com/kubeflow/kubeflow
     source-type: git
-    source-tag: v1.8-branch  # upstream branch
+    source-tag: v1.8-branch
     source-depth: 1
     build-packages:
       - python3-venv

--- a/jupyter-web-app/rockcraft.yaml
+++ b/jupyter-web-app/rockcraft.yaml
@@ -1,24 +1,25 @@
-# Based on https://github.com/kubeflow/kubeflow/blob/master/components/crud-web-apps/jupyter/Dockerfile
+# Based on https://github.com/kubeflow/kubeflow/blob/v1.8-branch/components/crud-web-apps/jupyter/Dockerfile
 name: jupyter-web-app
 summary: An image for Jupyter UI
 description: |
   This image is used as part of Charmed Kubeflow product. Jupyter UI web application provides
   users with web UI to access and manipulate Jupyter Notebooks in Charmed Kubeflow.
-version: v1.8.0_20.04_1 # version format: <KF-upstream-version>_<base-version>_<ROCK-version>
+version: "1.8"
 license: Apache-2.0
-base: ubuntu:20.04
+base: ubuntu@22.04
+platforms:
+  amd64:
 run-user: _daemon_
+
 services:
   jupyter-ui:
     override: replace
-    summary: "jupyter-ui service"
+    summary: "Jupyter web app service"
     startup: enabled
     command: "/bin/bash -c gunicorn -w 3 --bind 0.0.0.0:5000 --access-logfile - entrypoint:app"
+    working-dir: "/src/"
     environment:
       PYTHONPATH: "/"
-platforms:
-  amd64:
-
 parts:
   backend:
     plugin: nil
@@ -32,9 +33,15 @@ parts:
       - python3-pip
     override-build: |
       python3 -m pip install wheel
-      cd components/crud-web-apps/common/backend
+      # Create a directory that holds the src of the backend copied
+      # from the CRAFT_PART_SRC directory to avoid bringing files that
+      # could affect the build of the backend wheel.
+      # This measure helps keeping the rockcraft and the Dockerfile files
+      # as similar as possible in terms of the operations they perform.
+      # This is replicated in other steps for the frontend.
+      mkdir $CRAFT_STAGE/backend-src && cd $CRAFT_STAGE/backend-src
+      cp -r $CRAFT_PART_SRC/components/crud-web-apps/common/backend/* $CRAFT_STAGE/backend-src/
       python3 setup.py bdist_wheel
-      cp dist/kubeflow-1.1-py3-none-any.whl $CRAFT_STAGE
 
   frontend-lib:
     plugin: nil
@@ -47,10 +54,15 @@ parts:
     build-environment:
       - NG_CLI_ANALYTICS: "ci"
     override-build: |
-      cd components/crud-web-apps/common/frontend/kubeflow-common-lib
+      mkdir $CRAFT_STAGE/frontend-lib-src/ && cd $CRAFT_STAGE/frontend-lib-src/
+      cp $CRAFT_PART_SRC/components/crud-web-apps/common/frontend/kubeflow-common-lib/package.json $CRAFT_STAGE/frontend-lib-src/
+      cp $CRAFT_PART_SRC/components/crud-web-apps/common/frontend/kubeflow-common-lib/package-lock.json $CRAFT_STAGE/frontend-lib-src/
       npm ci
+
+      cp -r $CRAFT_PART_SRC/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/ $CRAFT_STAGE/frontend-lib-src/projects
+      cp $CRAFT_PART_SRC/components/crud-web-apps/common/frontend/kubeflow-common-lib/angular.json $CRAFT_STAGE/frontend-lib-src/
+      cp $CRAFT_PART_SRC/components/crud-web-apps/common/frontend/kubeflow-common-lib/tsconfig.json $CRAFT_STAGE/frontend-lib-src/
       npm run build
-      cp -r dist/kubeflow/ $CRAFT_STAGE
 
   frontend:
     after: [frontend-lib]
@@ -64,30 +76,20 @@ parts:
     build-environment:
       - NG_CLI_ANALYTICS: "ci"
     override-build: |
-      cd components/crud-web-apps/jupyter/frontend
+      mkdir $CRAFT_STAGE/frontend-src/ && cd $CRAFT_STAGE/frontend-src/
+      cp $CRAFT_PART_SRC/components/crud-web-apps/jupyter/frontend/package.json $CRAFT_STAGE/frontend-src/
+      cp $CRAFT_PART_SRC/components/crud-web-apps/jupyter/frontend/package-lock.json $CRAFT_STAGE/frontend-src/
+      cp $CRAFT_PART_SRC/components/crud-web-apps/jupyter/frontend/tsconfig.json $CRAFT_STAGE/frontend-src/
+      cp $CRAFT_PART_SRC/components/crud-web-apps/jupyter/frontend/tsconfig.app.json $CRAFT_STAGE/frontend-src/
+      cp $CRAFT_PART_SRC/components/crud-web-apps/jupyter/frontend/tsconfig.spec.json $CRAFT_STAGE/frontend-src/
+      cp $CRAFT_PART_SRC/components/crud-web-apps/jupyter/frontend/angular.json $CRAFT_STAGE/frontend-src/
+      mkdir $CRAFT_STAGE/frontend-src/src/
+      cp -r $CRAFT_PART_SRC/components/crud-web-apps/jupyter/frontend/src/* $CRAFT_STAGE/frontend-src/src/
       npm ci
-      cp -r $CRAFT_STAGE/kubeflow/ ./node_modules/  # TODO confirm
-      npm run build -- --output-path=./dist/default --configuration=production
-      cp -r dist/default $CRAFT_STAGE
 
-  webapp:
-    after: [backend, frontend]
-    plugin: nil
-    source: https://github.com/kubeflow/kubeflow
-    source-type: git
-    source-tag: v1.8-branch  # upstream branch
-    source-depth: 1
-    build-packages:
-      - python3-venv
-      - python3-setuptools
-      - python3-pip
-    override-build: |
-      pip3 install $CRAFT_STAGE/kubeflow-1.1-py3-none-any.whl
-      cd components/crud-web-apps/jupyter/backend
-      cp -r $CRAFT_STAGE/default apps/default/static/
-      cp -r apps $CRAFT_PART_INSTALL
-      cp entrypoint.py $CRAFT_PART_INSTALL
-      cp -r /usr/local/lib/python3.8/dist-packages/* $CRAFT_PRIME
+      mkdir -p $CRAFT_STAGE/frontend-src/node_modules/kubeflow
+      cp -r $CRAFT_STAGE/frontend-lib-src/dist/kubeflow/* $CRAFT_STAGE/frontend-src/node_modules/kubeflow
+      npm run build -- --output-path=$CRAFT_STAGE/frontend-src/dist/default --configuration=production
 
   gunicorn:
     plugin: python
@@ -99,11 +101,32 @@ parts:
     stage-packages:
     - python3-venv
 
+  webapp:
+    after: [backend, frontend, gunicorn]
+    plugin: nil
+    source: https://github.com/kubeflow/kubeflow
+    source-type: git
+    source-tag: v1.8-branch  # upstream branch
+    source-depth: 1
+    build-packages:
+      - python3-venv
+      - python3-setuptools
+      - python3-pip
+    override-build: |
+      cd $CRAFT_STAGE/backend-src/ && pip install .
+
+      # Promote the packages we've installed from the local env to the primed image
+      mkdir -p $CRAFT_PART_INSTALL/usr/local/lib/python3.10/dist-packages
+      cp -fr /usr/local/lib/python3.10/dist-packages/* $CRAFT_PART_INSTALL/usr/local/lib/python3.10/dist-packages/
+
+      mkdir $CRAFT_PART_INSTALL/src && cd $CRAFT_PART_INSTALL/src
+      mkdir $CRAFT_PART_INSTALL/src/apps/
+      cp -r $CRAFT_PART_SRC/components/crud-web-apps/jupyter/backend/apps/* $CRAFT_PART_INSTALL/src/apps/
+      cp -r $CRAFT_PART_SRC/components/crud-web-apps/jupyter/backend/entrypoint.py $CRAFT_PART_INSTALL/src/
+      cp -r $CRAFT_STAGE/frontend-src/dist/default/ $CRAFT_PART_INSTALL/src/apps/default/static
+
   security-team-requirement:
     plugin: nil
     override-build: |
       mkdir -p ${CRAFT_PART_INSTALL}/usr/share/rocks
-      (echo "# os-release" && cat /etc/os-release && echo "# dpkg-query" && \
-      dpkg-query -f '${db:Status-Abbrev},${binary:Package},${Version},${source:Package},${Source:Version}\n' -W) \
-      > ${CRAFT_PART_INSTALL}/usr/share/rocks/dpkg.query
-
+      (echo "# os-release" && cat /etc/os-release && echo "# dpkg-query" && dpkg-query -f '${db:Status-Abbrev},${binary:Package},${Version},${source:Package},${Source:Version}\n' -W) > ${CRAFT_PART_INSTALL}/usr/share/rocks/dpkg.query

--- a/jupyter-web-app/rockcraft.yaml
+++ b/jupyter-web-app/rockcraft.yaml
@@ -47,7 +47,7 @@ parts:
     plugin: nil
     source: https://github.com/kubeflow/kubeflow
     source-type: git
-    source-tag: v1.8-branch  # upstream branch
+    source-tag: v1.8-branch
     source-depth: 1
     build-snaps:
       - node/12/stable
@@ -69,7 +69,7 @@ parts:
     plugin: nil
     source: https://github.com/kubeflow/kubeflow
     source-type: git
-    source-tag: v1.8-branch  # upstream branch
+    source-tag: v1.8-branch
     source-depth: 1
     build-snaps:
       - node/12/stable
@@ -94,7 +94,7 @@ parts:
   gunicorn:
     plugin: python
     source: https://github.com/kubeflow/kubeflow.git
-    source-tag: v1.8-branch  # upstream branch
+    source-tag: v1.8-branch
     source-depth: 1
     python-requirements:
     - components/crud-web-apps/jupyter/backend/requirements.txt
@@ -106,7 +106,7 @@ parts:
     plugin: nil
     source: https://github.com/kubeflow/kubeflow
     source-type: git
-    source-tag: v1.8-branch  # upstream branch
+    source-tag: v1.8-branch
     source-depth: 1
     build-packages:
       - python3-venv

--- a/jupyter-web-app/tests/test_rock.py
+++ b/jupyter-web-app/tests/test_rock.py
@@ -1,0 +1,66 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+#
+#
+
+from pathlib import Path
+
+import os
+import logging
+import random
+import pytest
+import string
+import subprocess
+import yaml
+
+from charmed_kubeflow_chisme.rock import CheckRock
+
+
+@pytest.fixture()
+def rock_test_env(tmpdir):
+    """Yields a temporary directory and random docker container name, then cleans them up after."""
+    container_name = "".join(
+        [str(i) for i in random.choices(string.ascii_lowercase, k=8)]
+    )
+    yield tmpdir, container_name
+
+    try:
+        subprocess.run(["docker", "rm", container_name])
+    except Exception:
+        pass
+    # tmpdir fixture we use here should clean up the other files for us
+
+
+@pytest.mark.abort_on_fail
+def test_rock(rock_test_env):
+    """Test rock."""
+    temp_dir, container_name = rock_test_env
+    check_rock = CheckRock("rockcraft.yaml")
+    rock_image = check_rock.get_name()
+    rock_version = check_rock.get_version()
+    LOCAL_ROCK_IMAGE = f"{rock_image}:{rock_version}"
+
+    subprocess.run(
+        [
+            "docker",
+            "run",
+            LOCAL_ROCK_IMAGE,
+            "exec",
+            "ls",
+            "-la",
+            "/src",
+        ],
+        check=True,
+    )
+
+    subprocess.run(
+        [
+            "docker",
+            "run",
+            LOCAL_ROCK_IMAGE,
+            "exec",
+            "cat",
+            "/src/entrypoint.py",
+        ],
+        check=True,
+    )

--- a/jupyter-web-app/tox.ini
+++ b/jupyter-web-app/tox.ini
@@ -1,45 +1,61 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 [tox]
 skipsdist = True
 skip_missing_interpreters = True
+envlist = pack, export-to-docker, sanity, integration
 
 [testenv]
 setenv =
     PYTHONPATH={toxinidir}
     PYTHONBREAKPOINT=ipdb.set_trace
-    CHARM_REPO=https://github.com/canonical/notebook-operators.git
-    CHARM_BRANCH=main
-    LOCAL_CHARM_DIR=charm_repo
 
+[testenv:pack]
+passenv = *
+allowlist_externals =
+    rockcraft
+commands =
+    rockcraft pack
+
+[testenv:export-to-docker]
+passenv = *
+allowlist_externals =
+    bash
+    skopeo
+    yq
+commands =
+    # export already packed rock to docker
+    bash -c 'NAME=$(yq eval .name rockcraft.yaml) && \
+             VERSION=$(yq eval .version rockcraft.yaml) && \
+             ARCH=$(yq eval ".platforms | keys | .[0]" rockcraft.yaml) && \
+             ROCK="$\{NAME\}_$\{VERSION\}_$\{ARCH\}.rock" && \
+             DOCKER_IMAGE=$NAME:$VERSION && \\
+             echo "Exporting $ROCK to docker as $DOCKER_IMAGE" && \
+             skopeo --insecure-policy copy oci-archive:$ROCK docker-daemon:$DOCKER_IMAGE'
+
+[testenv:sanity]
+passenv = *
+deps =
+    pytest
+    charmed-kubeflow-chisme
+allowlist_externals =
+    echo
+commands =
+    # run rock tests
+    pytest -v --tb native --show-capture=all --log-cli-level=INFO {posargs} {toxinidir}/tests
 
 [testenv:integration]
 passenv = *
 allowlist_externals =
+    echo
     bash
     git
     rm
     tox
-    rockcraft
 deps =
     juju<4.0
     pytest
     pytest-operator
     ops
 commands =
-    # build and pack rock
-    rockcraft pack
-    # clone related charm
-    rm -rf {env:LOCAL_CHARM_DIR}
-    git clone --branch {env:CHARM_BRANCH} {env:CHARM_REPO} {env:LOCAL_CHARM_DIR}
-    # upload rock to docker and microk8s cache, replace charm's container with local rock reference
-    bash -c 'NAME=$(yq eval .name rockcraft.yaml) && \
-             VERSION=$(yq eval .version rockcraft.yaml) && \
-             ARCH=$(yq eval -r ".platforms | keys" rockcraft.yaml | cut -d" " -f2) && \
-             ROCK="$\{NAME\}_$\{VERSION\}_$\{ARCH\}" && \
-             sudo skopeo --insecure-policy copy oci-archive:$ROCK.rock docker-daemon:$ROCK:$VERSION && \
-             docker save $ROCK > $ROCK.tar && \
-             microk8s ctr image import $ROCK.tar && \
-             yq e -i ".resources.oci-image.upstream-source=\"$ROCK:$VERSION\"" {env:LOCAL_CHARM_DIR}/charms/jupyter-ui/metadata.yaml'
-    # run charm integration test with rock
-    tox -c {env:LOCAL_CHARM_DIR} -e ui-integration
+    echo "WARNING: This is a placeholder test - no test is implemented here."

--- a/jupyter-web-app/tox.ini
+++ b/jupyter-web-app/tox.ini
@@ -9,7 +9,7 @@ envlist = pack, export-to-docker, sanity, integration
 setenv =
     PYTHONPATH={toxinidir}
     PYTHONBREAKPOINT=ipdb.set_trace
-    CHARM_REPO=https://github.com/canonical/notebook-operators.git
+    CHARM_REPO=https://github.com/canonical/kserve-operators.git
     CHARM_BRANCH=main
     LOCAL_CHARM_DIR=charm_repo
 
@@ -27,7 +27,7 @@ allowlist_externals =
     skopeo
     yq
 commands =
-    # pack rock and export to docker
+    # export rock to docker
     bash -c 'NAME=$(yq eval .name rockcraft.yaml) && \
              VERSION=$(yq eval .version rockcraft.yaml) && \
              ARCH=$(yq eval ".platforms | keys | .[0]" rockcraft.yaml) && \

--- a/jupyter-web-app/tox.ini
+++ b/jupyter-web-app/tox.ini
@@ -9,6 +9,9 @@ envlist = pack, export-to-docker, sanity, integration
 setenv =
     PYTHONPATH={toxinidir}
     PYTHONBREAKPOINT=ipdb.set_trace
+    CHARM_REPO=https://github.com/canonical/notebook-operators.git
+    CHARM_BRANCH=main
+    LOCAL_CHARM_DIR=charm_repo
 
 [testenv:pack]
 passenv = *
@@ -24,12 +27,12 @@ allowlist_externals =
     skopeo
     yq
 commands =
-    # export already packed rock to docker
+    # pack rock and export to docker
     bash -c 'NAME=$(yq eval .name rockcraft.yaml) && \
              VERSION=$(yq eval .version rockcraft.yaml) && \
              ARCH=$(yq eval ".platforms | keys | .[0]" rockcraft.yaml) && \
              ROCK="$\{NAME\}_$\{VERSION\}_$\{ARCH\}.rock" && \
-             DOCKER_IMAGE=$NAME:$VERSION && \\
+             DOCKER_IMAGE=$NAME:$VERSION && \
              echo "Exporting $ROCK to docker as $DOCKER_IMAGE" && \
              skopeo --insecure-policy copy oci-archive:$ROCK docker-daemon:$DOCKER_IMAGE'
 
@@ -38,24 +41,14 @@ passenv = *
 deps =
     pytest
     charmed-kubeflow-chisme
-allowlist_externals =
-    echo
 commands =
     # run rock tests
-    pytest -v --tb native --show-capture=all --log-cli-level=INFO {posargs} {toxinidir}/tests
+    pytest -s -v --tb native --show-capture=all --log-cli-level=INFO {posargs} {toxinidir}/tests
 
 [testenv:integration]
 passenv = *
 allowlist_externals =
     echo
-    bash
-    git
-    rm
-    tox
-deps =
-    juju<4.0
-    pytest
-    pytest-operator
-    ops
 commands =
+    # TODO: Implement integration tests here
     echo "WARNING: This is a placeholder test - no test is implemented here."

--- a/jupyter-web-app/tox.ini
+++ b/jupyter-web-app/tox.ini
@@ -9,7 +9,7 @@ envlist = pack, export-to-docker, sanity, integration
 setenv =
     PYTHONPATH={toxinidir}
     PYTHONBREAKPOINT=ipdb.set_trace
-    CHARM_REPO=https://github.com/canonical/kserve-operators.git
+    CHARM_REPO=https://github.com/canonical/notebook-operators.git
     CHARM_BRANCH=main
     LOCAL_CHARM_DIR=charm_repo
 


### PR DESCRIPTION
This commit refactors the rockcraft project to use the latest standards for writing rocks. It also adds sanity checks and a tox.ini file so this image gets tested in the CI.

Fixes #80

#### Testing instructions

Prerequisites:
* skopeo
* docker

1. Build the rock `rockcraft pack -v`
2. Save the rock as an OCI image in docker's local registry `skopeo --insecure-policy copy oci-archive:<rock name>.rock docker-daemon:jwa:0.1`
3. Run a container with the image and replace the entrypoint with a shell `docker run --rm -ti jwa:0.1`
4. Ensure the service gets started correctly. NOTE: Because the container image needs kubeconfig and proper expose of a the serving port, the output of the command could have the following errors:

```
kubernetes.config.config_exception.ConfigException: Service host/port is not set.
kubernetes.config.config_exception.ConfigException: Invalid kube-config file. No configuration found.
```

But to check the validity of the image, one can run the following and observe the output before the mentioned errors:

```
$ cd /src
$ gunicorn -w 3 --bind 0.0.0.0:5000 --access-logfile - entrypoint:app
[2024-04-03 15:25:58 +0000] [13] [INFO] Starting gunicorn 21.2.0
[2024-04-03 15:25:58 +0000] [13] [INFO] Listening at: http://0.0.0.0:5000 (13)
[2024-04-03 15:25:58 +0000] [13] [INFO] Using worker: sync
[2024-04-03 15:25:58 +0000] [14] [INFO] Booting worker with pid: 14
[2024-04-03 15:25:58 +0000] [15] [INFO] Booting worker with pid: 15
[2024-04-03 15:25:58 +0000] [16] [INFO] Booting worker with pid: 16
[2024-04-03 15:25:59 +0000] [14] [ERROR] Exception in worker process
```