### PR TITLE
fix: refactor the command to match upstream's

### DIFF
--- a/jupyter-web-app/rockcraft.yaml
+++ b/jupyter-web-app/rockcraft.yaml
@@ -16,7 +16,7 @@ services:
     override: replace
     summary: "Jupyter web app service"
     startup: enabled
-    command: "/bin/bash -c gunicorn -w 3 --bind 0.0.0.0:5000 --access-logfile - entrypoint:app"
+    command: '/bin/bash -c "gunicorn -w 3 --bind 0.0.0.0:5000 --access-logfile - entrypoint:app"'
     working-dir: "/src/"
     environment:
       PYTHONPATH: "/"


### PR DESCRIPTION
The command was incorrectly formatted, resulting in an error: `Error: No application module specified.`
This commit ensures the command actually runs as it is expected from the upstream image.

#### Testing instructions

Prerequisites:
* skopeo
* docker

1. Build the rock `rockcraft pack -v`
2. Save the rock as an OCI image in docker's local registry `skopeo --insecure-policy copy oci-archive:<rock name>.rock docker-daemon:jwa:0.1`
3. Run a container with the image and replace the entrypoint with a shell `docker run --rm -ti jwa:0.1`
4. Ensure the service gets started correctly. NOTE: Because the container image needs kubeconfig and proper expose of a the serving port, the output of the command could have the following errors:

```
kubernetes.config.config_exception.ConfigException: Service host/port is not set.
kubernetes.config.config_exception.ConfigException: Invalid kube-config file. No configuration found.
```