### PR TITLE
chore: fix rocks terminology

### DIFF
--- a/.github/workflows/build_and_publish_rock.yaml
+++ b/.github/workflows/build_and_publish_rock.yaml
@@ -1,4 +1,4 @@
-# reusable workflow for publishing a ROCK
+# reusable workflow for publishing a rock
 name: Build and publish rock
 
 on:
@@ -29,7 +29,7 @@ on:
 
 jobs:
   build-publish-rock:
-    name: Build and publish ROCK
+    name: Build and publish rock
     uses: canonical/charmed-kubeflow-workflows/.github/workflows/build_and_publish_rock.yaml@main
     with:
       rock-dir: ${{ inputs.rock-dir }}

--- a/.github/workflows/on_pull_request.yaml
+++ b/.github/workflows/on_pull_request.yaml
@@ -6,7 +6,7 @@ on:
 jobs:
 
   on-pull-request:
-    name: Get ROCKs modified and build-scan-test them
+    name: Get rocks modified and build-scan-test them
     uses: canonical/charmed-kubeflow-workflows/.github/workflows/get-rocks-modified-and-build-scan-test-publish.yaml@main
     permissions:
       pull-requests: read

--- a/.github/workflows/on_push.yaml
+++ b/.github/workflows/on_push.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
 
   on-push:
-    name: Get ROCKs modified and build-scan-test-publish them
+    name: Get rocks modified and build-scan-test-publish them
     uses: canonical/charmed-kubeflow-workflows/.github/workflows/get-rocks-modified-and-build-scan-test-publish.yaml@main
     permissions:
       pull-requests: read

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Kubeflow ROCKs
+# Kubeflow Rocks
 
-Collection of ROCKs for Kubeflow components.
+Collection of [rocks](https://canonical-rockcraft.readthedocs-hosted.com/en/latest/explanation/rocks/) for Kubeflow components.
 
 # Development notes
 - Rockcraft tutorial:
@@ -12,16 +12,16 @@ Collection of ROCKs for Kubeflow components.
 - Use `build-packages` and `build-snaps` for build stage. Those will not be used by application. As a result, if build and application require the same package, it needs to be in both `build-packages` and `stage-packages`
 - If issues with LXD/Docker arise review firewall setup:
   https://linuxcontainers.org/lxd/docs/master/howto/network_bridge_firewalld/
-- While building ROCKs these commands are very helpful:
+- While building rocks these commands are very helpful:
   ```
   rockcraft clean
   lxc --project rockcraft image list
   ```
-- Entry point in ROCK is Pebble. At this point there is no way to specify other entry point. To start container, a Pebble layer is added via adding `001-deafault.yaml` file to `/var/lib/pebble/default/layers/`. Refer to source code for more details.
+- The rock's entrypoint is [Pebble](https://canonical-rockcraft.readthedocs-hosted.com/en/latest/explanation/pebble/). At this point, there is no way to specify other entrypoint. A Pebble layer is added via adding the `001-deafault.yaml` file to `/var/lib/pebble/default/layers/` (Rockcraft does that). Refer to source code for more details.
 
-# Building ROCKs
+# Building Rocks
 
-To build ROCK images for Kubeflow components:
+To build rocks for Kubeflow components:
 ```
 cd <image-directory>
 rockcraft pack

--- a/centraldashboard/tests/test_rock.py
+++ b/centraldashboard/tests/test_rock.py
@@ -40,7 +40,7 @@ def test_rock(rock_test_env):
     rock_version = check_rock.get_version()
     LOCAL_ROCK_IMAGE = f"{rock_image}:{rock_version}"
 
-    # create ROCK filesystem
+    # create rock filesystem
     subprocess.run(
         [
             "docker",

--- a/jupyter-pytorch-cuda-full/rockcraft.yaml
+++ b/jupyter-pytorch-cuda-full/rockcraft.yaml
@@ -172,7 +172,7 @@ parts:
       cp -r "${CONDA_DIR}" "${CRAFT_PART_INSTALL}/opt/conda"
       cp -r "${HOME}" "${CRAFT_PART_INSTALL}/${HOME}"
 
-  # not-root user for this ROCK should be 'jovyan'
+  # not-root user for this rock should be 'jovyan'
   non-root-user:
     plugin: nil
     after: [conda-jupyter]

--- a/jupyter-pytorch-cuda-full/tests/test_rock.py
+++ b/jupyter-pytorch-cuda-full/tests/test_rock.py
@@ -19,7 +19,7 @@ def test_rock(ops_test: OpsTest):
     rock_image = f"{name}_{rock_version}_{arch}"
     LOCAL_ROCK_IMAGE = f"{rock_image}:{rock_version}"
 
-    # verify ROCK service
+    # verify rock service
     rock_services = rock["services"]
     assert rock_services["jupyter"]
     assert rock_services["jupyter"]["startup"] == "enabled"

--- a/jupyter-pytorch-full/rockcraft.yaml
+++ b/jupyter-pytorch-full/rockcraft.yaml
@@ -205,7 +205,7 @@ parts:
       cp -r "${CONDA_DIR}" "${CRAFT_PART_INSTALL}/opt/conda"
       cp -r "${HOME}" "${CRAFT_PART_INSTALL}/${HOME}"
 
-  # not-root user for this ROCK should be 'jovyan'
+  # not-root user for this rock should be 'jovyan'
   non-root-user:
     plugin: nil
     after: [conda-jupyter]

--- a/jupyter-pytorch-full/tests/test_rock.py
+++ b/jupyter-pytorch-full/tests/test_rock.py
@@ -16,7 +16,7 @@ def test_rock():
     rock_services = check_rock.get_services()
     LOCAL_ROCK_IMAGE = f"{rock_image}:{rock_version}"
 
-    # verify ROCK service
+    # verify rock service
     assert rock_services["jupyter"]
     assert rock_services["jupyter"]["startup"] == "enabled"
 

--- a/jupyter-scipy/rockcraft.yaml
+++ b/jupyter-scipy/rockcraft.yaml
@@ -167,7 +167,7 @@ parts:
       cp -r "${CONDA_DIR}" "${CRAFT_PART_INSTALL}/opt/conda"
       cp -r "${HOME}" "${CRAFT_PART_INSTALL}/${HOME}"
 
-  # not-root user for this ROCK should be 'jovyan'
+  # not-root user for this rock should be 'jovyan'
   non-root-user:
     plugin: nil
     after: [conda-jupyter]

--- a/jupyter-scipy/tests/test_rock.py
+++ b/jupyter-scipy/tests/test_rock.py
@@ -19,7 +19,7 @@ def test_rock(ops_test: OpsTest):
     rock_image = f"{name}_{rock_version}_{arch}"
     LOCAL_ROCK_IMAGE = f"{rock_image}:{rock_version}"
 
-    # verify ROCK service
+    # verify rock service
     rock_services = rock["services"]
     assert rock_services["jupyter"]
     assert rock_services["jupyter"]["startup"] == "enabled"

--- a/jupyter-tensorflow-cuda-full/rockcraft.yaml
+++ b/jupyter-tensorflow-cuda-full/rockcraft.yaml
@@ -230,7 +230,7 @@ parts:
       cp -rp "${CONDA_DIR}" "${CRAFT_PART_INSTALL}/opt/conda"
       cp -rp "${HOME}" "${CRAFT_PART_INSTALL}/${HOME}"
 
-  # not-root user for this ROCK should be 'jovyan'
+  # not-root user for this rock should be 'jovyan'
   non-root-user:
     plugin: nil
     after: [conda-jupyter]

--- a/jupyter-tensorflow-cuda-full/tests/test_rock.py
+++ b/jupyter-tensorflow-cuda-full/tests/test_rock.py
@@ -19,7 +19,7 @@ def test_rock(ops_test: OpsTest):
     rock_image = f"{name}_{rock_version}_{arch}"
     LOCAL_ROCK_IMAGE = f"{rock_image}:{rock_version}"
 
-    # verify ROCK service
+    # verify rock service
     rock_services = rock["services"]
     assert rock_services["jupyter"]
     assert rock_services["jupyter"]["startup"] == "enabled"

--- a/jupyter-tensorflow-full/rockcraft.yaml
+++ b/jupyter-tensorflow-full/rockcraft.yaml
@@ -174,7 +174,7 @@ parts:
       cp -r "${CONDA_DIR}" "${CRAFT_PART_INSTALL}/opt/conda"
       cp -r "${HOME}" "${CRAFT_PART_INSTALL}/${HOME}"
 
-  # not-root user for this ROCK should be 'jovyan'
+  # not-root user for this rock should be 'jovyan'
   non-root-user:
     plugin: nil
     after: [conda-jupyter]

--- a/jupyter-tensorflow-full/tests/test_rock.py
+++ b/jupyter-tensorflow-full/tests/test_rock.py
@@ -19,7 +19,7 @@ def test_rock(ops_test: OpsTest):
     rock_image = f"{name}_{rock_version}_{arch}"
     LOCAL_ROCK_IMAGE = f"{rock_image}:{rock_version}"
 
-    # verify ROCK service
+    # verify rock service
     rock_services = rock["services"]
     assert rock_services["jupyter"]
     assert rock_services["jupyter"]["startup"] == "enabled"


### PR DESCRIPTION
Simply renaming all upper case references of "ROCK" to "rock". Also added a couple of links to the README.md.