### PR TITLE
docs: replace ROCKs with rocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Kubeflow ROCKs
+# Kubeflow rocks
 
-Collection of ROCKs for Kubeflow components.
+Collection of rocks for Kubeflow components.
 
 # Development notes
 - Rockcraft tutorial:
@@ -12,16 +12,16 @@ Collection of ROCKs for Kubeflow components.
 - Use `build-packages` and `build-snaps` for build stage. Those will not be used by application. As a result, if build and application require the same package, it needs to be in both `build-packages` and `stage-packages`
 - If issues with LXD/Docker arise review firewall setup:
   https://linuxcontainers.org/lxd/docs/master/howto/network_bridge_firewalld/
-- While building ROCKs these commands are very helpful:
+- While building rocks these commands are very helpful:
   ```
   rockcraft clean
   lxc --project rockcraft image list
   ```
-- Entry point in ROCK is Pebble. At this point there is no way to specify other entry point. To start container, a Pebble layer is added via adding `001-deafault.yaml` file to `/var/lib/pebble/default/layers/`. Refer to source code for more details.
+- Entry point in rock is Pebble. At this point there is no way to specify other entry point. To start container, a Pebble layer is added via adding `001-deafault.yaml` file to `/var/lib/pebble/default/layers/`. Refer to source code for more details.
 
-# Building ROCKs
+# Building rocks
 
-To build ROCK images for Kubeflow components:
+To build rock images for Kubeflow components:
 ```
 cd <image-directory>
 rockcraft pack


### PR DESCRIPTION
This commit replaces ROCKs with rocks to be in sync with Canonical's standard terminology.

Part of canonical/bundle-kubeflow#916