### PR TITLE
chore: bump jupyter-web-app to 1.9.0-rc.0

### DIFF
--- a/jupyter-web-app/rockcraft.yaml
+++ b/jupyter-web-app/rockcraft.yaml
@@ -1,10 +1,10 @@
-# Based on https://github.com/kubeflow/kubeflow/blob/v1.8-branch/components/crud-web-apps/jupyter/Dockerfile
+# Based on https://github.com/kubeflow/kubeflow/blob/v1.9.0-rc.0/components/crud-web-apps/jupyter/Dockerfile
 name: jupyter-web-app
 summary: An image for Jupyter UI
 description: |
   This image is used as part of Charmed Kubeflow product. Jupyter UI web application provides
   users with web UI to access and manipulate Jupyter Notebooks in Charmed Kubeflow.
-version: "1.8"
+version: "1.9.0"
 license: Apache-2.0
 base: ubuntu@22.04
 platforms:
@@ -25,7 +25,7 @@ parts:
     plugin: nil
     source: https://github.com/kubeflow/kubeflow
     source-type: git
-    source-tag: v1.8-branch
+    source-tag: v1.9.0-rc.0
     source-depth: 1
     build-packages:
       - python3-venv
@@ -47,7 +47,7 @@ parts:
     plugin: nil
     source: https://github.com/kubeflow/kubeflow
     source-type: git
-    source-tag: v1.8-branch
+    source-tag: v1.9.0-rc.0
     source-depth: 1
     build-snaps:
       - node/12/stable
@@ -69,7 +69,7 @@ parts:
     plugin: nil
     source: https://github.com/kubeflow/kubeflow
     source-type: git
-    source-tag: v1.8-branch
+    source-tag: v1.9.0-rc.0
     source-depth: 1
     build-snaps:
       - node/12/stable
@@ -94,7 +94,7 @@ parts:
   gunicorn:
     plugin: python
     source: https://github.com/kubeflow/kubeflow.git
-    source-tag: v1.8-branch
+    source-tag: v1.9.0-rc.0
     source-depth: 1
     python-requirements:
     - components/crud-web-apps/jupyter/backend/requirements.txt
@@ -106,7 +106,7 @@ parts:
     plugin: nil
     source: https://github.com/kubeflow/kubeflow
     source-type: git
-    source-tag: v1.8-branch
+    source-tag: v1.9.0-rc.0
     source-depth: 1
     build-packages:
       - python3-venv


### PR DESCRIPTION
IIRC we generally do not include the `rc` part of the tag in the image's version.

Closes #89