### PR TITLE
chore: bump centraldashboard image to 1.9.0-rc.0

### DIFF
--- a/centraldashboard/rockcraft.yaml
+++ b/centraldashboard/rockcraft.yaml
@@ -1,5 +1,5 @@
 # Dockerfile https://github.com/kubeflow/kubeflow/blob/v1.9.0-rc.0/components/centraldashboard/Dockerfile
-name: kubeflow-central-dashboard
+name: centraldashboard
 summary: Kubeflow Landing Page
 description: |
   This component serves as the landing page and central dashboard for Kubeflow deployments.

--- a/centraldashboard/rockcraft.yaml
+++ b/centraldashboard/rockcraft.yaml
@@ -1,10 +1,10 @@
-# Dockerfile https://github.com/kubeflow/kubeflow/blob/v1.8-branch/components/centraldashboard/Dockerfile
+# Dockerfile https://github.com/kubeflow/kubeflow/blob/v1.9.0-rc.0/components/centraldashboard/Dockerfile
 name: kubeflow-central-dashboard
 summary: Kubeflow Landing Page
 description: |
   This component serves as the landing page and central dashboard for Kubeflow deployments.
   It provides a jump-off point to all other facets of the platform.
-version: "1.8"
+version: "1.9.0"
 license: Apache-2.0
 base: ubuntu@22.04
 platforms:
@@ -17,7 +17,7 @@ services:
     summary: "Kubeflow central dashboard service"
     command: "/usr/bin/npm start"
     startup: enabled
-    working-dir: "/app"
+    working-dir: "/usr/src/app"
     environment:
       NODE_ENV: production
 
@@ -33,9 +33,9 @@ parts:
     source: https://github.com/kubeflow/kubeflow
     source-subdir: components/centraldashboard
     source-type: git
-    source-tag: v1.8-branch # upstream branch
+    source-tag: v1.9.0-rc.0 # upstream branch
     build-snaps:
-      - node/14/stable
+      - node/16/stable
     build-packages:
       - bash
       - chromium-browser
@@ -49,7 +49,7 @@ parts:
     build-environment:
       - CHROME_BIN: /usr/bin/chromium-browser
       - PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: true
-      - BUILD_VERSION: "1.8"
+      - BUILD_VERSION: "1.9"
     stage-packages:
       - nodejs
       - npm
@@ -65,17 +65,15 @@ parts:
       # will be built w/o flags for other architectures for simplicity.
       # Please refer to the upstream Dockerfile if that condition changes and different
       # architectures need to be supported.
-      npm rebuild && \
-      npm install && \
-      npm test && \
+      npm ci && \
       npm run build && \
       npm prune --production
 
       # install build artifacts
-      mkdir -p ${CRAFT_PART_INSTALL}/app
-      cp -r ${CRAFT_PART_SRC}/components/centraldashboard/* ${CRAFT_PART_INSTALL}/app
+      mkdir -p ${CRAFT_PART_INSTALL}/usr/src/app
+      cp -r ${CRAFT_PART_SRC}/components/centraldashboard/* ${CRAFT_PART_INSTALL}/usr/src/app
 
-      # Change permissions of the /app directory to
+      # Change permissions of the /usr/src/app directory to
       # be owned by the _daemon_ user
-      chown 584792:584792 ${CRAFT_PART_INSTALL}/app
-      chmod 755 ${CRAFT_PART_INSTALL}/app
+      chown 584792:584792 ${CRAFT_PART_INSTALL}/usr/src/app
+      chmod 755 ${CRAFT_PART_INSTALL}/usr/src/app

--- a/centraldashboard/tests/test_rock.py
+++ b/centraldashboard/tests/test_rock.py
@@ -49,7 +49,7 @@ def test_rock(rock_test_env):
             "exec",
             "ls",
             "-la",
-            "/app",
+            "/usr/src/app",
         ],
         check=True,
     )


### PR DESCRIPTION
Diff between [1.8-branch](https://github.com/kubeflow/kubeflow/blob/v1.8-branch/components/centraldashboard/Dockerfile#L36) and [1.9.0-rc.0 tag](https://github.com/kubeflow/kubeflow/blob/v1.9.0-rc.0/components/centraldashboard/Dockerfile#L27) -> https://www.diffchecker.com/JaCMol7i/.

Note that this PR renames also the `name` version since in order to:
1. follow the upstream name as we do in most of our rocks
2. follow the convention where rock directory and rock name are the same

#### Testing
1. `usr/src/app` directory is tested by sanity tests
3. Check that image runs and logs the same with upstream image
```
# upstream image
 ╰─$ docker run --rm kubeflownotebookswg/centraldashboard:v1.9.0-rc.0                                        

> kubeflow-centraldashboard@0.0.2 start
> npm run serve


> kubeflow-centraldashboard@0.0.2 serve
> node dist/server.js

Initializing Kubernetes configuration
Unable to fetch Nodes Error: connect ECONNREFUSED 127.0.0.1:8080
    at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1278:16) {
  errno: -111,
  code: 'ECONNREFUSED',
  syscall: 'connect',
  address: '127.0.0.1',
  port: 8080
}
Unable to fetch Application information: Error: connect ECONNREFUSED 127.0.0.1:8080
    at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1278:16) {
  errno: -111,
  code: 'ECONNREFUSED',
  syscall: 'connect',
  address: '127.0.0.1',
  port: 8080
}
Unable to fetch Nodes Error: connect ECONNREFUSED 127.0.0.1:8080
    at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1278:16) {
  errno: -111,
  code: 'ECONNREFUSED',
  syscall: 'connect',
  address: '127.0.0.1',
  port: 8080
}
"other" is not a supported platform for Metrics
Using Profiles service at http://profiles-kfam.kubeflow:8081/kfam
Server listening on port http://localhost:8082 (in production mode)

# rock
╰─$ docker run --rm kubeflow-central-dashboard:1.9.0
2024-06-10T07:15:24.561Z [pebble] Started daemon.
2024-06-10T07:15:24.568Z [pebble] POST /v1/services 4.42732ms 202
2024-06-10T07:15:24.572Z [pebble] Service "serve" starting: /usr/bin/npm start
2024-06-10T07:15:25.107Z [serve] 
2024-06-10T07:15:25.107Z [serve] > kubeflow-centraldashboard@0.0.2 start
2024-06-10T07:15:25.107Z [serve] > npm run serve
2024-06-10T07:15:25.107Z [serve] 
2024-06-10T07:15:25.576Z [pebble] GET /v1/changes/1/wait 1.006711635s 200
2024-06-10T07:15:25.576Z [pebble] Started default services with change 1.
2024-06-10T07:15:25.611Z [serve] 
2024-06-10T07:15:25.611Z [serve] > kubeflow-centraldashboard@0.0.2 serve
2024-06-10T07:15:25.611Z [serve] > node dist/server.js
2024-06-10T07:15:25.611Z [serve] 
2024-06-10T07:15:26.829Z [serve] Initializing Kubernetes configuration
2024-06-10T07:15:26.857Z [serve] Unable to fetch Nodes Error: connect ECONNREFUSED 127.0.0.1:8080
2024-06-10T07:15:26.857Z [serve]     at TCPConnectWrap.afterConnect [as oncomplete] (net.js:1138:16) {
2024-06-10T07:15:26.857Z [serve]   errno: 'ECONNREFUSED',
2024-06-10T07:15:26.857Z [serve]   code: 'ECONNREFUSED',
2024-06-10T07:15:26.857Z [serve]   syscall: 'connect',
2024-06-10T07:15:26.857Z [serve]   address: '127.0.0.1',
2024-06-10T07:15:26.857Z [serve]   port: 8080
2024-06-10T07:15:26.857Z [serve] }
2024-06-10T07:15:26.858Z [serve] Unable to fetch Application information: Error: connect ECONNREFUSED 127.0.0.1:8080
2024-06-10T07:15:26.858Z [serve]     at TCPConnectWrap.afterConnect [as oncomplete] (net.js:1138:16) {
2024-06-10T07:15:26.858Z [serve]   errno: 'ECONNREFUSED',
2024-06-10T07:15:26.858Z [serve]   code: 'ECONNREFUSED',
2024-06-10T07:15:26.858Z [serve]   syscall: 'connect',
2024-06-10T07:15:26.858Z [serve]   address: '127.0.0.1',
2024-06-10T07:15:26.858Z [serve]   port: 8080
2024-06-10T07:15:26.858Z [serve] }
2024-06-10T07:15:26.858Z [serve] Unable to fetch Nodes Error: connect ECONNREFUSED 127.0.0.1:8080
2024-06-10T07:15:26.858Z [serve]     at TCPConnectWrap.afterConnect [as oncomplete] (net.js:1138:16) {
2024-06-10T07:15:26.858Z [serve]   errno: 'ECONNREFUSED',
2024-06-10T07:15:26.858Z [serve]   code: 'ECONNREFUSED',
2024-06-10T07:15:26.858Z [serve]   syscall: 'connect',
2024-06-10T07:15:26.858Z [serve]   address: '127.0.0.1',
2024-06-10T07:15:26.858Z [serve]   port: 8080
2024-06-10T07:15:26.858Z [serve] }
2024-06-10T07:15:26.859Z [serve] "other" is not a supported platform for Metrics
2024-06-10T07:15:26.859Z [serve] Using Profiles service at http://profiles-kfam.kubeflow:8081/kfam
2024-06-10T07:15:26.866Z [serve] Server listening on port http://localhost:8082 (in production mode)
```

Closes #91