### PR TITLE
Change service name to match the name defined in kubeflow-dashboard-o…

### DIFF
--- a/centraldashboard/rockcraft.yaml
+++ b/centraldashboard/rockcraft.yaml
@@ -12,7 +12,7 @@ platforms:
 run-user: _daemon_
 
 services:
-  serve:
+  kubeflow-dashboard:
     override: replace
     summary: "Kubeflow central dashboard service"
     command: "/usr/bin/npm start"


### PR DESCRIPTION
Closes #104 along with [this PR](https://github.com/canonical/kubeflow-dashboard-operator/pull/221) on the kubeflow-dashboard-operator repo.

This PR changes the name of the service, in order to match the name defined in the Pebble layer of the kubeflow-dashboard charm. Along with this [this change](https://github.com/canonical/kubeflow-dashboard-operator/pull/221), the values in the rock are propagated to the Pebble config layer in the charm, thus the `working-dir` variable doesn't need to be defined there.