### PR TITLE
backport: Change service name to match the name defined in kubeflow-dashboard

### DIFF
--- a/centraldashboard/rockcraft.yaml
+++ b/centraldashboard/rockcraft.yaml
@@ -12,7 +12,7 @@ platforms:
 run-user: _daemon_
 
 services:
-  serve:
+  kubeflow-dashboard:
     override: replace
     summary: "Kubeflow central dashboard service"
     command: "/usr/bin/npm start"


### PR DESCRIPTION
This PR is a backport of PR #120, and along with [this PR](https://github.com/canonical/kubeflow-dashboard-operator/pull/225) fix issue #104.