### PR TITLE
fix: place the webhook binary in the expected path

### DIFF
--- a/admission-webhook/rockcraft.yaml
+++ b/admission-webhook/rockcraft.yaml
@@ -1,3 +1,4 @@
+# From https://github.com/kubeflow/kubeflow/blob/v1.9-branch/components/admission-webhook/Dockerfile
 name: admission-webhook
 base: ubuntu@20.04
 version: v1.9.0
@@ -16,7 +17,7 @@ platforms:
 services:
   base-admission-webhook:
     override: merge
-    command: "admission-webhook"
+    command: "/webhook"
     startup: enabled
     user: ubuntu
 
@@ -27,14 +28,23 @@ parts:
       mkdir -p ${CRAFT_PART_INSTALL}/usr/share/rocks
       (echo "# os-release" && cat /etc/os-release && echo "# dpkg-query" && dpkg-query -f '${db:Status-Abbrev},${binary:Package},${Version},${source:Package},${Source:Version}\n' -W) > ${CRAFT_PART_INSTALL}/usr/share/rocks/dpkg.query
 
+  # The go plugin uses go install to build and install the "admission-webhook" binary at
+  # /bin/admission-webhook, which is undesirable as it is expected to be in /webhook.
+  # The go plugin does not offer any mechanism for passing custom install paths, so we have
+  # to use override-build instead to make sure the binary is placed in the expected path.
   admission-webhook:
     plugin: go
     build-snaps:
       - go/1.21/stable
     source: https://github.com/kubeflow/kubeflow.git
-    source-tag: v1.9.0
-    source-depth: 1
-    source-subdir: components/admission-webhook
+    source-tag: v1.9-branch
+    build-environment:
+      - CGO_ENABLED: 0
+      - GOOS: linux
+    override-build: |
+      cd components/admission-webhook
+      go build -o webhook -a .
+      cp webhook $CRAFT_PART_INSTALL/webhook
 
   non-root-user:
     plugin: nil

--- a/admission-webhook/rockcraft.yaml
+++ b/admission-webhook/rockcraft.yaml
@@ -43,8 +43,7 @@ parts:
       - GOOS: linux
     override-build: |
       cd components/admission-webhook
-      go build -o webhook -a .
-      cp webhook $CRAFT_PART_INSTALL/webhook
+      go build -o $CRAFT_PART_INSTALL/webhook -a .
 
   non-root-user:
     plugin: nil

--- a/admission-webhook/tests/test_rock.py
+++ b/admission-webhook/tests/test_rock.py
@@ -49,7 +49,7 @@ def test_rock(rock_test_env):
             "exec",
             "ls",
             "-la",
-            "/bin/admission-webhook",
+            "/webhook",
         ],
         check=True,
     )


### PR DESCRIPTION
The path to the webhook binary was modified by #124, causing runtime issues when running the container image with the expected /webhook entrypoint. This commit ensures the binary is placed in the expected path.

Fixes #127


#### Testing instructions

1. Pack `rockcraft pack -v`
2. Save the rock as oci-image `skopeo --insecure-policy copy oci-archive:admission-webhook_v1.9.0_arm64.rock docker-daemon:webhook:0.1`
3. Run the image in a container `docker run --rm -ti --entrypoint /bin/bash webhook:0.1`
4. Verify the `/webhook` binary is present
5. Additionally, this image can be replaced in the charm