### PR TITLE
Udate profile-controller v1.9.0

### DIFF
--- a/profile-controller/rockcraft.yaml
+++ b/profile-controller/rockcraft.yaml
@@ -2,7 +2,7 @@
 
 name: profile-controller
 base: ubuntu@22.04
-version: "v1.9.0"
+version: "1.9.0"
 summary: Controller for Kubeflow Profile objects
 description: Controller for Kubeflow Profile objects
 license: Apache-2.0

--- a/profile-controller/rockcraft.yaml
+++ b/profile-controller/rockcraft.yaml
@@ -1,21 +1,17 @@
-# Constructed from https://github.com/kubeflow/kubeflow/blob/v1.8.0/components/profile-controller/Dockerfile
+# Constructed from https://github.com/kubeflow/kubeflow/blob/v1.9.0/components/profile-controller/Dockerfile
 
 name: profile-controller
+base: ubuntu@22.04
+version: "v1.9.0"
 summary: Controller for Kubeflow Profile objects
 description: Controller for Kubeflow Profile objects
-version: "v1.8.0"
-
-# TODO: use base: bare
-base: ubuntu@22.04
-build-base: ubuntu@22.04
-
 license: Apache-2.0
 
 platforms:
   amd64:
 
 services:
-  profile-controller:
+  kubeflow-profiles:
     command: /manager
     override: replace
     startup: enabled
@@ -23,20 +19,24 @@ services:
     user: ubuntu
 
 parts:
+  security-team-requirement:
+    plugin: nil
+    override-build: |
+      mkdir -p ${CRAFT_PART_INSTALL}/usr/share/rocks
+      (echo "# os-release" && cat /etc/os-release && echo "# dpkg-query" && dpkg-query -f '${db:Status-Abbrev},${binary:Package},${Version},${source:Package},${Source:Version}\n' -W) > ${CRAFT_PART_INSTALL}/usr/share/rocks/dpkg.query
+
   profile-controller:
     plugin: go
     source-type: git
     source: https://github.com/kubeflow/kubeflow.git
-    source-tag: v1.8.0
+    source-tag: v1.9.0
     source-subdir: components/profile-controller
     build-environment:
       - CGO_ENABLED: 0
       - GOOS: linux
-      # - GO111MODULE: on  # Not needed, but wasn't clear why.  Something snap related
     build-snaps:
       - go/1.17/stable
-    # Build the go code and output to $CRAFT_PART_INSTALL
-    # Copy the hashcorp libs used during build for later staging
+    # Override-build because we want to move the hashicorp librarry folder
     override-build: |
       cd $CRAFT_PART_SRC_WORK
       go mod download
@@ -57,7 +57,3 @@ parts:
       # Create a user in the $CRAFT_OVERLAY chroot
       groupadd -R $CRAFT_OVERLAY -g 1001 ubuntu
       useradd -R $CRAFT_OVERLAY -M -r -u 1001 -g ubuntu ubuntu
-
-  # TODO: Need to add the security-team-requirement part like 
-  #       [here](https://github.com/canonical/kubeflow-rocks/blob/main/admission-webhook/rockcraft.yaml#L24)
-  #       but this part needs to be refactored first to work with rockcraft

--- a/profile-controller/rockcraft.yaml
+++ b/profile-controller/rockcraft.yaml
@@ -36,7 +36,7 @@ parts:
       - GOOS: linux
     build-snaps:
       - go/1.17/stable
-    # Override-build because we want to move the hashicorp librarry folder
+    # Override-build because we want to move the hashicorp library folder
     override-build: |
       cd $CRAFT_PART_SRC_WORK
       go mod download


### PR DESCRIPTION
Closes: https://github.com/canonical/kubeflow-rocks/issues/131

No changes from 1.8.0 to 1.9.0. But I have:
- changed the service to match the service in the charm
- added security team requirements 
- refactored structure to match other rocks

I have locally tested with the charm and integraiton tests are passing

To test rock:
```
rockcraft clean && rockcraft pack --verbosity=trace --debug
sudo rockcraft.skopeo --insecure-policy copy oci-archive:profile-controller_v1.9.0_amd64.rock docker-daemon:misohu/profile-controller:v1.9.0
docker run -ti misohu/profile-controller:v1.9.0 -v
```

expected output:
```
2024-09-11T11:25:23.561Z [pebble] Started daemon.
2024-09-11T11:25:23.597Z [pebble] POST /v1/services 16.823408ms 202
2024-09-11T11:25:23.613Z [pebble] Service "kubeflow-profiles" starting: /manager
2024-09-11T11:25:23.641Z [kubeflow-profiles] 1.726053923641294e+09      ERROR   controller-runtime.client.config        unable to get kubeconfig        {"error": "invalid configuration: no configuration has been provided, try setting KUBERNETES_MASTER environment variable", "errorCauses": [{"error": "no configuration has been provided, try setting KUBERNETES_MASTER environment variable"}]}
2024-09-11T11:25:23.641Z [kubeflow-profiles] sigs.k8s.io/controller-runtime/pkg/client/config.GetConfigOrDie
2024-09-11T11:25:23.641Z [kubeflow-profiles]    /root/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.12.1/pkg/client/config/config.go:153
2024-09-11T11:25:23.641Z [kubeflow-profiles] main.main
2024-09-11T11:25:23.641Z [kubeflow-profiles]    /root/parts/profile-controller/src/components/profile-controller/main.go:87
2024-09-11T11:25:23.641Z [kubeflow-profiles] runtime.main
2024-09-11T11:25:23.641Z [kubeflow-profiles]    /snap/go/9949/src/runtime/proc.go:255
2024-09-11T11:25:23.657Z [pebble] Change 1 task (Start service "kubeflow-profiles") failed: cannot start service: exited quickly with code 1
2024-09-11T11:25:23.700Z [pebble] GET /v1/changes/1/wait 101.650667ms 200
2024-09-11T11:25:23.700Z [pebble] Started default services with change 1.
```
