### PR TITLE
Udate kfam v1.9.0

### DIFF
--- a/kfam/rockcraft.yaml
+++ b/kfam/rockcraft.yaml
@@ -38,7 +38,7 @@ parts:
     build-environment:
       - CGO_ENABLED: 0
       - GOOS: linux
-    # Override-build because we want to move the hashicorp librarry folder
+    # Override-build because we want to move the hashicorp library folder
     override-build: |
       # cd into $CRAFT_PART_SRC_WORK due to https://github.com/canonical/craft-parts/issues/427
       cd $CRAFT_PART_SRC_WORK

--- a/kfam/rockcraft.yaml
+++ b/kfam/rockcraft.yaml
@@ -1,11 +1,12 @@
 #!/usr/bin/env python3
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
+# Constructed from https://github.com/kubeflow/kubeflow/blob/v1.9.0/components/access-management/Dockerfile
 
 name: kfam
 summary: Kubeflow Access Management API
 description: Kubeflow Access Management API provides fine-grain user-namespace level access control.
-version: "v1.8.0"
+version: "v1.9.0"
 license: Apache-2.0
 base: ubuntu@22.04
 
@@ -13,13 +14,19 @@ platforms:
   amd64:
 
 services:
-  access-manager:
+  kubeflow-kfam:
     override: replace
-    command: "/access-management -cluster-admin admin -userid-header kubeflow-userid -userid-prefix ''"
+    command: "/access-management"
     startup: enabled
     user: ubuntu
 
 parts:
+  security-team-requirement:
+    plugin: nil
+    override-build: |
+      mkdir -p ${CRAFT_PART_INSTALL}/usr/share/rocks
+      (echo "# os-release" && cat /etc/os-release && echo "# dpkg-query" && dpkg-query -f '${db:Status-Abbrev},${binary:Package},${Version},${source:Package},${Source:Version}\n' -W) > ${CRAFT_PART_INSTALL}/usr/share/rocks/dpkg.query
+
   kfam:
     plugin: go
     build-snaps:
@@ -27,10 +34,11 @@ parts:
     source: https://github.com/kubeflow/kubeflow.git
     source-subdir: components/access-management
     source-type: git
-    source-tag: v1.8.0
+    source-tag: v1.9.0
     build-environment:
       - CGO_ENABLED: 0
       - GOOS: linux
+    # Override-build because we want to move the hashicorp librarry folder
     override-build: |
       # cd into $CRAFT_PART_SRC_WORK due to https://github.com/canonical/craft-parts/issues/427
       cd $CRAFT_PART_SRC_WORK
@@ -39,12 +47,6 @@ parts:
       chmod a+rx $CRAFT_PART_INSTALL/access-management
       cp -r third_party $CRAFT_PART_INSTALL/third_party
       cp -r /root/go/pkg/mod/github.com/hashicorp $CRAFT_PART_INSTALL/third_party/library/
-
-      # security requirement
-      mkdir -p ${CRAFT_PART_INSTALL}/usr/share/rocks
-      (echo "# os-release" && cat /etc/os-release && echo "# dpkg-query" && \
-      dpkg-query -f '${db:Status-Abbrev},${binary:Package},${Version},${source:Package},${Source:Version}\n' -W) \
-      > ${CRAFT_PART_INSTALL}/usr/share/rocks/dpkg.query
 
   non-root-user:
     plugin: nil

--- a/kfam/rockcraft.yaml
+++ b/kfam/rockcraft.yaml
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 # Constructed from https://github.com/kubeflow/kubeflow/blob/v1.9.0/components/access-management/Dockerfile
@@ -6,7 +5,7 @@
 name: kfam
 summary: Kubeflow Access Management API
 description: Kubeflow Access Management API provides fine-grain user-namespace level access control.
-version: "v1.9.0"
+version: "1.9.0"
 license: Apache-2.0
 base: ubuntu@22.04
 


### PR DESCRIPTION
Closes: https://github.com/canonical/kubeflow-rocks/issues/132

No changes from 1.8.0 to 1.9.0. But I have:
- changed the service to match the service in the charm
- added security team requirements 
- refactored structure to match other rocks

I have locally tested with the charm and integraiton tests are passing

To test rock:
```
rockcraft clean && rockcraft pack --verbosity=trace --debug
sudo rockcraft.skopeo --insecure-policy copy oci-archive:kfam_v1.9.0_amd64.rock docker-daemon:misohu/kfam:v1.9.0
docker run -ti misohu/kfam:v1.9.0 -v
```

expected output:
```
2024-09-11T11:30:26.095Z [pebble] Started daemon.
2024-09-11T11:30:26.127Z [pebble] POST /v1/services 16.163427ms 202
2024-09-11T11:30:26.144Z [pebble] Service "kubeflow-kfam" starting: /access-management
2024-09-11T11:30:26.164Z [kubeflow-kfam] time="2024-09-11T11:30:26Z" level=info msg="Server started"
2024-09-11T11:30:26.164Z [kubeflow-kfam] time="2024-09-11T11:30:26Z" level=info msg="could not locate a kubeconfig"
2024-09-11T11:30:26.166Z [kubeflow-kfam] panic: could not locate a kubeconfig
2024-09-11T11:30:26.166Z [kubeflow-kfam] 
2024-09-11T11:30:26.166Z [kubeflow-kfam] goroutine 1 [running]:
2024-09-11T11:30:26.166Z [kubeflow-kfam] main.main()
2024-09-11T11:30:26.166Z [kubeflow-kfam]        /root/parts/kfam/src/components/access-management/main.go:52 +0x467
2024-09-11T11:30:26.183Z [pebble] Change 1 task (Start service "kubeflow-kfam") failed: cannot start service: exited quickly with code 2
2024-09-11T11:30:26.214Z [pebble] GET /v1/changes/1/wait 85.347868ms 200
2024-09-11T11:30:26.215Z [pebble] Started default services with change 1.
```
