### PR TITLE
Update Pebble service name for admission-webhook

### DIFF
--- a/admission-webhook/rockcraft.yaml
+++ b/admission-webhook/rockcraft.yaml
@@ -16,7 +16,7 @@ platforms:
 
 services:
   admission-webhook:
-    override: replace
+    override: merge
     command: "/webhook"
     startup: enabled
     user: ubuntu

--- a/admission-webhook/rockcraft.yaml
+++ b/admission-webhook/rockcraft.yaml
@@ -15,7 +15,7 @@ platforms:
   amd64:
 
 services:
-  base-admission-webhook:
+  admission-webhook:
     override: merge
     command: "/webhook"
     startup: enabled

--- a/admission-webhook/rockcraft.yaml
+++ b/admission-webhook/rockcraft.yaml
@@ -16,7 +16,7 @@ platforms:
 
 services:
   admission-webhook:
-    override: merge
+    override: replace
     command: "/webhook"
     startup: enabled
     user: ubuntu


### PR DESCRIPTION
Closes #136.

This PR simply changes the name of the Pebble service in the `admission-webhook` rock to match the container name defined in the charm operator's code, found [here](https://github.com/canonical/admission-webhook-operator/blob/70384d3e24df19d637a3f74454d4a96f5cd263cc/src/charm.py#L49). This way, only one Pebble service is created.

To test:
- Clone the repository and checkout to this branch
- `cd` to the `admission-webhook` directory and run `tox -e pack`
- `tox -e export-to-docker`
- Clone the `admission-webhook-operator` repository, found [here](https://github.com/canonical/admission-webhook-operator).
- Change the value of `oci-image` in `metadata.yaml` to the image name that was exported (prepending `docker.io/library/` to the image name).
- Run the integration tests with `tox -e integration -- --model kubeflow`
- Tests should pass :)