### PR TITLE
ci: enable scheduled trivy scanner and report vulnerabilities as GH issues

### DIFF
--- a/.github/workflows/scan_images.yaml
+++ b/.github/workflows/scan_images.yaml
@@ -1,0 +1,21 @@
+name: Scan images
+
+on:  
+  schedule:
+    - cron: '00 23 * * *'
+  workflow_dispatch:
+
+jobs:
+
+  on-push:
+    name: Get rocks modified and build-scan-test-publish them
+    uses: canonical/charmed-kubeflow-workflows/.github/workflows/get-published-images-scan-and-report.yaml@main
+    strategy:
+      matrix:
+        branch: [main, track/1.8]
+    secrets:
+      GH_TOKEN: ${{ secrets.GH_TOKEN }}
+    with:
+      report-vulnerabilities: true
+      severity: "HIGH,CRITICAL"
+      branch: ${{ matrix.branch }}

--- a/.github/workflows/scan_images.yaml
+++ b/.github/workflows/scan_images.yaml
@@ -7,8 +7,8 @@ on:
 
 jobs:
 
-  on-push:
-    name: Get rocks modified and build-scan-test-publish them
+  scan-images:
+    name: Scan published images and report vulnerabilities
     uses: canonical/charmed-kubeflow-workflows/.github/workflows/get-published-images-scan-and-report.yaml@main
     strategy:
       matrix:


### PR DESCRIPTION
This workflow enables a scheduled scanner (that can also be run from a workflow dispatch) to scan images using the trivy scanner. At the same time, enables the automatic creation/edition of Github issues when a vulnerability is found.

Fixes #139