### PR TITLE
feat: update `jupyter-scipy` rock for `1.10.0-rc`

### DIFF
--- a/jupyter-scipy/CONTRIBUTING.md
+++ b/jupyter-scipy/CONTRIBUTING.md
@@ -1,0 +1,69 @@
+# Contributing to Jupyter-SciPy Rock
+
+## Overview
+This Rock is built based on three upstream Dockerfiles from the Kubeflow project:
+
+- [Base Dockerfile](https://github.com/kubeflow/kubeflow/blob/v1.10.0-rc.0/components/example-notebook-servers/base/Dockerfile)
+- [Jupyter Dockerfile](https://github.com/kubeflow/kubeflow/blob/v1.10.0-rc.0/components/example-notebook-servers/jupyter/Dockerfile)
+- [Jupyter-SciPy Dockerfile](https://github.com/kubeflow/kubeflow/blob/v1.10.0-rc.0/components/example-notebook-servers/jupyter-scipy/Dockerfile)
+
+If you are updating this Rock, ensure you check the above Dockerfiles from top to bottom to track any modifications.
+
+## Architecture and Scope
+The upstream Dockerfiles use `s6` to build images for different architectures, including ARM support. However, for this Rock, we are skipping `s6` for now.
+
+## Handling Environment Variables
+- Environment variables required for the build process are specified in the `parts` section of `rockcraft.yaml`.
+- Runtime environment variables are gathered and placed in the `services` section.
+- To check runtime environment variables:
+  ```sh
+  # Run the upstream Docker image
+  docker run kubeflownotebookswg/jupyter-scipy
+
+  # Get the process ID of Jupyter
+  docker exec -ti <container_id> bash
+  ps aux -ww
+
+  # Check the environment variables for the process
+  cat /proc/<process_id>/environ | tr '\0' '\n'
+  ```
+
+## Extracting the Command for the Rock
+The command used in the Rock's service section is derived by running the upstream Docker image and inspecting the active processes.
+To extract the correct command:
+
+```sh
+docker run kubeflownotebookswg/jupyter-scipy
+docker exec -ti <container_id> bash
+(base) jovyan@<container_id>:/$ ps aux -ww
+```
+
+Alternatively, you can check the upstream command file:
+[Run Script](https://github.com/kubeflow/kubeflow/blob/v1.10.0-rc.0/components/example-notebook-servers/jupyter/s6/services.d/jupyterlab/run)
+
+## Service Command Execution in Rock
+The command in the service definition must be wrapped with `bash -c`. This ensures that when the Rock is executed in a pod, environment variables such as `HOME` and `NB_PREFIX` are dynamically resolved. These variables should **not** be explicitly set in the service section, as their values depend on the specific notebook instance.
+
+### Example Service Command:
+```yaml
+command: bash -c './jupyter lab --notebook-dir=${HOME} --ip=0.0.0.0 --no-browser --allow-root --port=8888 --ServerApp.token="" --ServerApp.password="" --ServerApp.allow_origin="*" --ServerApp.allow_remote_access=True --ServerApp.base_url=${NB_PREFIX} --ServerApp.authenticate_prometheus=False'
+```
+
+## Preinstalling MLflow Library
+MLflow must be preinstalled in the Rock. The latest version can be checked [here](https://github.com/canonical/mlflow-operator/blob/main/metadata.yaml#L18).
+
+## Running the Rock Locally
+To build the Rock locally, use:
+```sh
+tox -e pack
+tox -e export-to-docker
+```
+
+Then, run it using:
+```sh
+docker run -p 8888:8888 jupyter-scipy:1.10.0-rc.0 exec /opt/conda/bin/jupyter lab --notebook-dir="/home/jovyan" --ip=0.0.0.0 --no-browser --allow-root --port=8888 --ServerApp.token="" --ServerApp.password="" --ServerApp.allow_origin="*" --ServerApp.allow_remote_access=True --ServerApp.base_url="/" --ServerApp.authenticate_prometheus=False
+```
+
+Now you should be able to access the notebook at http://localhost:8888/
+
+

--- a/jupyter-scipy/CONTRIBUTING.md
+++ b/jupyter-scipy/CONTRIBUTING.md
@@ -10,7 +10,13 @@ This Rock is built based on three upstream Dockerfiles from the Kubeflow project
 If you are updating this Rock, ensure you check the above Dockerfiles from top to bottom to track any modifications.
 
 ## Architecture and Scope
-The upstream Dockerfiles use `s6` to build images for different architectures, including ARM support. However, for this Rock, we are skipping `s6` for now.
+The upstream Dockerfiles use `s6` to build images for different architectures, including ARM support. However, for this Rock, we are skipping `s6` because we are not building for ARM.
+
+Additionally, we are skipping the following parts from the upstream Dockerfiles:
+- [`base/Dockerfile#L73`](https://github.com/kubeflow/kubeflow/blob/v1.10.0-rc.0/components/example-notebook-servers/base/Dockerfile#L73)
+- [`base/Dockerfile#L129`](https://github.com/kubeflow/kubeflow/blob/v1.10.0-rc.0/components/example-notebook-servers/base/Dockerfile#L129)
+
+We are also omitting environment variables related to `s6`.
 
 ## Handling Environment Variables
 - Environment variables required for the build process are specified in the `parts` section of `rockcraft.yaml`.
@@ -52,6 +58,8 @@ command: bash -c './jupyter lab --notebook-dir=${HOME} --ip=0.0.0.0 --no-browser
 ## Preinstalling MLflow Library
 MLflow must be preinstalled in the Rock. The latest version can be checked [here](https://github.com/canonical/mlflow-operator/blob/main/metadata.yaml#L18).
 
+The upstream Docker image does **not** install MLflow by default. This is required for integration purposes within the Charmed Kubeflow ecosystem.
+
 ## Running the Rock Locally
 To build the Rock locally, use:
 ```sh
@@ -65,5 +73,3 @@ docker run -p 8888:8888 jupyter-scipy:1.10.0-rc.0 exec /opt/conda/bin/jupyter la
 ```
 
 Now you should be able to access the notebook at http://localhost:8888/
-
-

--- a/jupyter-scipy/rockcraft.yaml
+++ b/jupyter-scipy/rockcraft.yaml
@@ -81,7 +81,23 @@ parts:
 
   nodejs:
     plugin: nil
-    stage-packages: [nodejs]
+    build-environment:
+      - NODE_MAJOR_VERSION: 20
+    override-build: |
+      # Add Node.js repository and install
+      export DEBIAN_FRONTEND=noninteractive
+      curl -sL "https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key" | apt-key add -
+      echo "deb https://deb.nodesource.com/node_${NODE_MAJOR_VERSION}.x nodistro main" > /etc/apt/sources.list.d/nodesource.list
+      apt-get -yq update
+      apt-get -yq install --no-install-recommends nodejs
+      apt-get clean
+      rm -rf /var/lib/apt/lists/*
+
+      # Create necessary directories in ${CRAFT_PART_INSTALL}
+      mkdir -p ${CRAFT_PART_INSTALL}/usr/bin
+
+      # Stage Node.js installation by copying the appropriate files
+      cp -r /usr/bin/node ${CRAFT_PART_INSTALL}/usr/bin/
 
   generate-locale:
     plugin: nil
@@ -209,6 +225,8 @@ parts:
       # Install mlflow so we can use this with mlflow https://github.com/canonical/data-science-stack/issues/47#issuecomment-2004136344
       "${CONDA_BIN}/pip" install --quiet --no-cache-dir \
         mlflow==${MLFLOW_VERSION}
+      
+      "${CONDA_BIN}/pip" install httpx==0.23.0
 
       # Create some directories for staging files
       # mkdir -p "${CRAFT_PART_INSTALL}/opt" "${CRAFT_PART_INSTALL}/etc" "${CRAFT_PART_INSTALL}/home"

--- a/jupyter-scipy/rockcraft.yaml
+++ b/jupyter-scipy/rockcraft.yaml
@@ -1,5 +1,5 @@
 # Based on:
-# https://github.com/kubeflow/kubeflow/tree/v1.10.0-rc.0/components/example-notebook-servers/base
+# https://github.com/kubeflow/kubeflow/blob/v1.10.0-rc.0/components/example-notebook-servers/base/Dockerfile
 # https://github.com/kubeflow/kubeflow/blob/v1.10.0-rc.0/components/example-notebook-servers/jupyter/Dockerfile
 # https://github.com/kubeflow/kubeflow/blob/v1.10.0-rc.0/components/example-notebook-servers/jupyter-scipy/Dockerfile
 name: jupyter-scipy
@@ -24,9 +24,10 @@ services:
       NB_USER: jovyan
       NB_UID: 1000
       NB_GID: 0
-      NB_PREFIX: /
       USERS_GID: 100
-      HOME: /home/jovyan
+      # The following environment variables need to be specified in the Pod's environment, and not hardcoded.
+      #HOME: ""
+      #NB_PREFIX: ""
       HOME_TMP: /tmp_home/jovyan
       SHELL: /bin/bash
       LANG: en_US.UTF-8
@@ -34,7 +35,7 @@ services:
       LC_ALL: en_US.UTF-8
       PATH: /opt/conda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
       PYTHONPATH: /opt/conda/lib/python3.11/site-packages/
-    command: ./jupyter lab --notebook-dir="/home/jovyan" --ip=0.0.0.0 --no-browser --port=8888 --ServerApp.token="" --ServerApp.password="" --ServerApp.allow_origin="*" --ServerApp.base_url="/" --ServerApp.authenticate_prometheus=False
+    command: bash -c './jupyter lab --notebook-dir=${HOME} --ip=0.0.0.0 --no-browser --port=8888 --ServerApp.token="" --ServerApp.password="" --ServerApp.allow_origin="*" --ServerApp.base_url=${NB_PREFIX} --ServerApp.authenticate_prometheus=False'
     working-dir: /opt/conda/bin/
 platforms:
   amd64:
@@ -226,6 +227,7 @@ parts:
       "${CONDA_BIN}/pip" install --quiet --no-cache-dir \
         mlflow==${MLFLOW_VERSION}
       
+      # Fixes the problem with pipy extension not loading in the jupyter
       "${CONDA_BIN}/pip" install httpx==0.23.0
 
       # Create some directories for staging files

--- a/jupyter-scipy/rockcraft.yaml
+++ b/jupyter-scipy/rockcraft.yaml
@@ -1,3 +1,7 @@
+# Based on:
+# https://github.com/kubeflow/kubeflow/tree/v1.10.0-rc.0/components/example-notebook-servers/base
+# https://github.com/kubeflow/kubeflow/blob/v1.10.0-rc.0/components/example-notebook-servers/jupyter/Dockerfile
+# https://github.com/kubeflow/kubeflow/blob/v1.10.0-rc.0/components/example-notebook-servers/jupyter-scipy/Dockerfile
 name: jupyter-scipy
 summary: An image for using Jupyter SciPy
 description: |
@@ -7,9 +11,9 @@ description: |
 
   Both SciPy and Jupyter are installed in Conda environment, which is
   automatically activated.
-version: v1.8.0_20.04_1 # version format: <KF-upstream-version>_<base-version>_<Charmed-KF-version>
+version: 1.10.0
 license: Apache-2.0
-base: ubuntu:20.04
+base: ubuntu@22.04
 run-user: _daemon_
 services:
   jupyter:
@@ -18,15 +22,18 @@ services:
     startup: enabled
     environment:
       NB_USER: jovyan
-      NB_UID: 1001
+      NB_UID: 1000
+      NB_GID: 0
       NB_PREFIX: /
+      USERS_GID: 100
       HOME: /home/jovyan
+      HOME_TMP: /tmp_home/jovyan
       SHELL: /bin/bash
       LANG: en_US.UTF-8
       LANGUAGE: en_US.UTF-8
       LC_ALL: en_US.UTF-8
       PATH: /opt/conda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-      PYTHONPATH: /opt/conda/lib/python3.8/site-packages/
+      PYTHONPATH: /opt/conda/lib/python3.11/site-packages/
     command: ./jupyter lab --notebook-dir="/home/jovyan" --ip=0.0.0.0 --no-browser --port=8888 --ServerApp.token="" --ServerApp.password="" --ServerApp.allow_origin="*" --ServerApp.base_url="/" --ServerApp.authenticate_prometheus=False
     working-dir: /opt/conda/bin/
 platforms:
@@ -66,7 +73,7 @@ parts:
   kubectl:
     plugin: nil
     stage-snaps:
-      - kubectl/1.25/stable
+      - kubectl/1.29/stable
     organize:
       kubectl: bin/kubectl
     stage:
@@ -91,20 +98,27 @@ parts:
     plugin: nil
     source: https://github.com/kubeflow/kubeflow
     source-type: git
-    source-tag: v1.8-branch # upstream branch
+    source-tag: v1.10.0-rc.0
     build-packages:
       - lsb-release
       - wget
     build-environment:
+      - JUPYTERLAB_VERSION: "4.2.5"
+      - JUPYTER_VERSION: "7.2.2"
       - MINIFORGE_ARCH: "x86_64"
-      - MINIFORGE_VERSION: "4.10.1-4"
-      - PIP_VERSION: "21.1.2"
-      - PYTHON_VERSION: "3.8.10"
+      - MINIFORGE_VERSION: "24.7.1-2"
+      - PIP_VERSION: "24.2"
+      - PYTHON_VERSION: "3.11.10"
       - HOME: "/home/jovyan"
+      - HOME_TMP: /tmp_home/jovyan
+      - NB_USER: jovyan
+      - NB_GID: 0
       - CONDA_DIR: "/opt/conda"
       - CONDA_BIN: "/opt/conda/bin"
+      - MAMBA_ROOT_PREFIX: "/opt/conda"
+      - MLFLOW_VERSION: "2.15.1"  # Latest mlflow version we support https://github.com/canonical/mlflow-operator/blob/main/metadata.yaml#L18
     stage-packages:
-      - python3.8-distutils
+      - python3.11-distutils
     override-build: |
       set -xe
       mkdir -p "${CONDA_DIR}" "${HOME}"
@@ -139,22 +153,72 @@ parts:
       # Clean up
       "${CONDA_BIN}/conda" update -y -q --all
       "${CONDA_BIN}/conda" clean -a -f -y
-
+      
       # Install the jupyter python requirements
+      echo "jupyterlab ==${JUPYTERLAB_VERSION}" >> ${CONDA_DIR}/conda-meta/pinned
+      echo "notebook ==${JUPYTER_VERSION}" >> ${CONDA_DIR}/conda-meta/pinned
+      "${CONDA_BIN}/conda" install -y -q \
+        jupyterlab==${JUPYTERLAB_VERSION} \
+        notebook==${JUPYTER_VERSION}
+      
       cp ${CRAFT_PART_SRC}/components/example-notebook-servers/jupyter/requirements.txt jupyter-requirements.txt
       "${CONDA_BIN}/pip" install --no-cache-dir -r jupyter-requirements.txt
-      
-      # Install the scipy requirements
-      cp ${CRAFT_PART_SRC}/components/example-notebook-servers/jupyter-scipy/requirements.txt scipy-requirements.txt
-      "${CONDA_BIN}/pip" install --no-cache-dir -r scipy-requirements.txt
+      rm -f /tmp/requirements.txt
 
-      # Generate a jupyter lab config
-      "${CONDA_BIN}/jupyter" lab --generate-config
+      # configure - jupyter
+      "${CONDA_BIN}/jupyter" labextension disable --level=system "@jupyterlab/apputils-extension:announcements" 
+      "${CONDA_BIN}/jupyter" labextension lock --level=system "@jupyterlab/apputils-extension"
+      
+      # Install the jupyter-scipy requirements
+      "${CONDA_BIN}/mamba" install -y -q \
+        altair \
+        beautifulsoup4==4.12.3 \
+        bokeh==3.3.4 \
+        bottleneck \
+        brotli \
+        cloudpickle \
+        dask==2024.5.1 \
+        dill \
+        h5py \
+        ipympl \
+        matplotlib==3.8.4 \
+        numba \
+        numexpr \
+        openblas==0.3.25 \
+        openpyxl \
+        pandas==2.1.4 \
+        patsy \
+        protobuf \
+        pytables==3.9.2 \
+        scikit-image==0.22.0 \
+        scikit-learn==1.3.2 \
+        scipy==1.11.3 \
+        seaborn==0.13.2 \
+        sqlalchemy==2.0.30 \
+        statsmodels \
+        sympy \
+        vincent \
+        xlrd \
+
+      "${CONDA_BIN}/mamba" clean -a -f -y
+      
+      cp $CRAFT_PART_SRC/components/example-notebook-servers/jupyter-scipy/requirements.txt /tmp/requirements.txt
+      "${CONDA_BIN}/pip" install --no-cache-dir -r /tmp/requirements.txt
+      rm -f /tmp/requirements.txt
+
+      # Install mlflow so we can use this with mlflow https://github.com/canonical/data-science-stack/issues/47#issuecomment-2004136344
+      "${CONDA_BIN}/pip" install --quiet --no-cache-dir \
+        mlflow==${MLFLOW_VERSION}
 
       # Create some directories for staging files
-      mkdir -p "${CRAFT_PART_INSTALL}/opt" "${CRAFT_PART_INSTALL}/etc" "${CRAFT_PART_INSTALL}/home"
+      # mkdir -p "${CRAFT_PART_INSTALL}/opt" "${CRAFT_PART_INSTALL}/etc" "${CRAFT_PART_INSTALL}/home"
+      mkdir -p "${CRAFT_PART_INSTALL}/${CONDA_DIR}" \
+      "${CRAFT_PART_INSTALL}/etc" \
+      "${CRAFT_PART_INSTALL}/${HOME}" \
+      "${CRAFT_PART_INSTALL}/${HOME_TMP}" \
 
       # Write some config files for activating conda in user sessions
+      chmod 2775 ${CRAFT_PART_INSTALL}/${CONDA_DIR}
       echo ". /opt/conda/etc/profile.d/conda.sh" >> "${HOME}/.bashrc"
       echo ". /opt/conda/etc/profile.d/conda.sh" >> "${CRAFT_PART_INSTALL}/etc/profile"
       echo "conda activate base" >> "${HOME}/.bashrc"
@@ -164,18 +228,34 @@ parts:
       rm -rf "${HOME}/.wget-hsts" "${HOME}/.cache"
 
       # Stage the conda directories
-      cp -r "${CONDA_DIR}" "${CRAFT_PART_INSTALL}/opt/conda"
-      cp -r "${HOME}" "${CRAFT_PART_INSTALL}/${HOME}"
+      cp -r "${CONDA_DIR}" "${CRAFT_PART_INSTALL}/opt"
+      cp -r "${HOME}" "${CRAFT_PART_INSTALL}/home"
 
   # not-root user for this rock should be 'jovyan'
   non-root-user:
     plugin: nil
     after: [conda-jupyter]
+    build-environment:
+    - HOME: /home/jovyan
+    - NB_UID: 1000
+    - NB_USER: jovyan
+    - NB_GID: 0
+    - USERS_GID: 100
     overlay-script: |
       # Create a user in the $CRAFT_OVERLAY chroot
-      useradd -R $CRAFT_OVERLAY -M -s /bin/bash -N -u 1001 jovyan
+      useradd -R ${CRAFT_OVERLAY} \
+      --shell /bin/bash \
+      --home ${HOME} \
+      --uid ${NB_UID} \
+      --gid ${NB_GID} \
+      --groups ${USERS_GID} \
+      ${NB_USER}
     override-prime: |
       craftctl default
-      chown -R 584792:users home/jovyan
-      chown -R 584792:users bin
-      chown -R 584792:users opt/conda
+      chmod 2775 ${CRAFT_PRIME}/home/${NB_USER}
+      chmod 2775 ${CRAFT_PRIME}/tmp_home/${NB_USER}
+      chown -R 584792:${NB_GID} ${CRAFT_PRIME}/home/${NB_USER}
+      chown -R 584792:${NB_GID} ${CRAFT_PRIME}/bin
+      chown -R 584792:${NB_GID} ${CRAFT_PRIME}/opt/conda
+      mkdir -pv ${CRAFT_PRIME}/usr/local/etc/jupyter
+      chown -R ${NB_UID}:${NB_GID} ${CRAFT_PRIME}/usr/local/etc/jupyter

--- a/jupyter-scipy/rockcraft.yaml
+++ b/jupyter-scipy/rockcraft.yaml
@@ -28,8 +28,8 @@ services:
       NB_UID: 1000
       NB_GID: 0
       USERS_GID: 100
+      HOME: "/home/jovyan"
       # The following environment variables need to be specified in the Pod's environment, and not hardcoded.
-      #HOME: ""
       #NB_PREFIX: ""
       HOME_TMP: /tmp_home/jovyan
       SHELL: /bin/bash
@@ -39,8 +39,8 @@ services:
       PATH: /opt/conda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
       PYTHONPATH: /opt/conda/lib/python3.11/site-packages/
     # Command source https://github.com/kubeflow/kubeflow/blob/v1.10.0-rc.0/components/example-notebook-servers/jupyter/s6/services.d/jupyterlab/run
-    command: bash -c './jupyter lab --notebook-dir=${HOME} --ip=0.0.0.0 --no-browser --allow-root --port=8888 --ServerApp.token="" --ServerApp.password="" --ServerApp.allow_origin="*" --ServerApp.allow_remote_access=True --ServerApp.base_url=${NB_PREFIX} --ServerApp.authenticate_prometheus=False'
-    working-dir: /opt/conda/bin/
+    command: bash -c '/opt/conda/bin/jupyter lab --notebook-dir=${HOME} --ip=0.0.0.0 --no-browser --allow-root --port=8888 --ServerApp.token="" --ServerApp.password="" --ServerApp.allow_origin="*" --ServerApp.allow_remote_access=True --ServerApp.base_url=${NB_PREFIX} --ServerApp.authenticate_prometheus=False'
+    working-dir: /home/jovyan/
 platforms:
   amd64:
 

--- a/jupyter-scipy/rockcraft.yaml
+++ b/jupyter-scipy/rockcraft.yaml
@@ -11,7 +11,7 @@ description: |
 
   Both SciPy and Jupyter are installed in Conda environment, which is
   automatically activated.
-version: 1.10.0
+version: 1.10.0-rc.0
 license: Apache-2.0
 base: ubuntu@22.04
 run-user: _daemon_
@@ -21,6 +21,9 @@ services:
     summary: "jupyter-scipy service"
     startup: enabled
     environment:
+      # To check the values run upstream docker image and run ps aux -ww to get the process id
+      # Environment variables for the process can be checked with cat /proc/<id>/environ | tr '\0' '\n'
+      JUPYTER_RUNTIME_DIR: /tmp/jupyter_runtime
       NB_USER: jovyan
       NB_UID: 1000
       NB_GID: 0
@@ -35,7 +38,8 @@ services:
       LC_ALL: en_US.UTF-8
       PATH: /opt/conda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
       PYTHONPATH: /opt/conda/lib/python3.11/site-packages/
-    command: bash -c './jupyter lab --notebook-dir=${HOME} --ip=0.0.0.0 --no-browser --port=8888 --ServerApp.token="" --ServerApp.password="" --ServerApp.allow_origin="*" --ServerApp.base_url=${NB_PREFIX} --ServerApp.authenticate_prometheus=False'
+    # Command source https://github.com/kubeflow/kubeflow/blob/v1.10.0-rc.0/components/example-notebook-servers/jupyter/s6/services.d/jupyterlab/run
+    command: bash -c './jupyter lab --notebook-dir=${HOME} --ip=0.0.0.0 --no-browser --allow-root --port=8888 --ServerApp.token="" --ServerApp.password="" --ServerApp.allow_origin="*" --ServerApp.allow_remote_access=True --ServerApp.base_url=${NB_PREFIX} --ServerApp.authenticate_prometheus=False'
     working-dir: /opt/conda/bin/
 platforms:
   amd64:
@@ -69,7 +73,12 @@ parts:
       - unzip
       - vim
       - wget
+      - xz-utils
       - zip
+      # jupyter scipy packages
+      - cm-super
+      - dvipng
+      - ffmpeg
 
   kubectl:
     plugin: nil
@@ -158,9 +167,6 @@ parts:
       "${CONDA_BIN}/conda" config --system --set auto_update_conda false
       "${CONDA_BIN}/conda" config --system --set show_channel_urls true
 
-      echo "conda ${MINIFORGE_VERSION:0:-2}" >> "${CONDA_DIR}/conda-meta/pinned"
-      echo "python ${PYTHON_VERSION}" >> "${CONDA_DIR}/conda-meta/pinned"
-
       # Install the correct versions of python, conda, pip
       "${CONDA_BIN}/conda" install -y -q \
                           python="${PYTHON_VERSION}" \
@@ -177,9 +183,10 @@ parts:
       "${CONDA_BIN}/conda" install -y -q \
         jupyterlab==${JUPYTERLAB_VERSION} \
         notebook==${JUPYTER_VERSION}
+      "${CONDA_BIN}/conda" clean -a -f -y
       
-      cp ${CRAFT_PART_SRC}/components/example-notebook-servers/jupyter/requirements.txt jupyter-requirements.txt
-      "${CONDA_BIN}/pip" install --no-cache-dir -r jupyter-requirements.txt
+      cp ${CRAFT_PART_SRC}/components/example-notebook-servers/jupyter/requirements.txt /tmp/requirements.txt
+      "${CONDA_BIN}/pip" install --no-cache-dir -r /tmp/requirements.txt
       rm -f /tmp/requirements.txt
 
       # configure - jupyter

--- a/jupyter-scipy/tests/imports.py
+++ b/jupyter-scipy/tests/imports.py
@@ -1,13 +1,17 @@
 #
 # This python script tests loading of required modules
 #
-# jupyter packages
+
+# Jupyter packages
 import jupyterlab
 import notebook
 import ipykernel
 
-# scipy packages
+# SciPy ecosystem packages
+import altair
 import bokeh
+import bottleneck
+import brotli
 import cloudpickle
 import dask
 import dill
@@ -18,19 +22,27 @@ import jupyterlab_git
 import matplotlib
 import numba
 import numexpr
+import openpyxl
 import pandas
 import patsy
-import google
 import scipy
 import seaborn
+import sqlalchemy
 import statsmodels
 import sympy
-import tables
+import tables  # pytables
 import vincent
 import xlrd
 
-# mlflow package
+# Machine Learning & Data Science
+import sklearn  # scikit-learn
+
+# MLflow package
 import mlflow
 
-# this string is expected by test script
+# OpenBLAS (Note: OpenBLAS itself is a C library, but NumPy uses it)
+import numpy as np
+import scipy.linalg  # Ensures OpenBLAS is properly linked
+
+# Test script success output
 print("PASSED")

--- a/jupyter-scipy/tests/imports.py
+++ b/jupyter-scipy/tests/imports.py
@@ -6,20 +6,9 @@ import jupyterlab
 import notebook
 import ipykernel
 
-# kubeflow packages
-# TO-DO verfiy proper kfp import. Upgrade mught be needed.
-#import kfp
-import kfp_server_api
-import kfserving
-
 # scipy packages
-# https://github.com/jupyter/docker-stacks/blob/master/scipy-notebook/Dockerfile
-# TO-DO verify how beautifulsoup4 is used/installed
-# /opt/conda/lib/python3.8/site-packages/beautifulsoup4-4.9.3.dist-info
-#import beautifulsoup4
 import bokeh
 import cloudpickle
-import cython
 import dask
 import dill
 import h5py
@@ -31,27 +20,17 @@ import numba
 import numexpr
 import pandas
 import patsy
-# TO-DO verfy how protobuf is installed
-# /opt/conda/lib/python3.8/site-packages/protobuf-3.17.3.dist-info
-#import protobuf
-# google contains protobuf, importing it instead
 import google
-# TO-DO verify how exactly scikit-image is installed
-# /opt/conda/lib/python3.8/site-packages/scikit_image-0.18.1.dist-info
-#import scikit_image
-# TO-DO verify how exactly scikit-learn is installed
-# /opt/conda/lib/python3.8/site-packages/scikit_learn-0.24.2.dist-info
-#import scikit_learn
 import scipy
 import seaborn
-# TO-DO verify how SQLAlchemy is installed
-# /opt/conda/lib/python3.8/site-packages/SQLAlchemy-1.4.18.dist-info
-#import SQLAlchemy
 import statsmodels
 import sympy
 import tables
 import vincent
 import xlrd
+
+# mlflow package
+import mlflow
 
 # this string is expected by test script
 print("PASSED")

--- a/jupyter-scipy/tests/test_access.py
+++ b/jupyter-scipy/tests/test_access.py
@@ -1,17 +1,13 @@
 #!/usr/bin/env python3
-# Copyright 2023 Canonical Ltd.
+# Copyright 2025 Canonical Ltd.
 # See LICENSE file for licensing details.
 #
 #
-from pathlib import Path
-
-import os
 import subprocess
-import time
 import requests
 import tenacity
-import yaml
 
+from charmed_kubeflow_chisme.rock import CheckRock
 
 @tenacity.retry(
 stop=tenacity.stop_after_attempt(5),
@@ -24,11 +20,9 @@ def check_notebook_server_up(url):
 
 def main():
     """Test running container and imports."""
-    rock = yaml.safe_load(Path("rockcraft.yaml").read_text())
-    name = rock["name"]
-    rock_version = rock["version"]
-    arch = list(rock["platforms"].keys())[0]
-    rock_image = f"{name}_{rock_version}_{arch}"
+    check_rock = CheckRock("rockcraft.yaml")
+    rock_image = check_rock.get_name()
+    rock_version = check_rock.get_version()
     LOCAL_ROCK_IMAGE = f"{rock_image}:{rock_version}"
     
     print(f"Running {LOCAL_ROCK_IMAGE}")

--- a/jupyter-scipy/tests/test_access.py
+++ b/jupyter-scipy/tests/test_access.py
@@ -26,11 +26,12 @@ def main():
     LOCAL_ROCK_IMAGE = f"{rock_image}:{rock_version}"
     
     print(f"Running {LOCAL_ROCK_IMAGE}")
-    container_id = subprocess.run(["docker", "run", "-d", "-p", "8888:8888", LOCAL_ROCK_IMAGE], stdout=subprocess.PIPE).stdout.decode('utf-8')
+    NB_PREFIX_DIR="test"
+    container_id = subprocess.run(["docker", "run", "-d", "-p", "8888:8888", "-e", f"NB_PREFIX={NB_PREFIX_DIR}", LOCAL_ROCK_IMAGE], stdout=subprocess.PIPE).stdout.decode('utf-8')
     container_id = container_id[0:12]
 
     # Try to reach the notebook server
-    output = check_notebook_server_up("http://0.0.0.0:8888/lab")
+    output = check_notebook_server_up(f"http://0.0.0.0:8888/{NB_PREFIX_DIR}/lab")
 
     # cleanup
     subprocess.run(["docker", "stop", f"{container_id}"])

--- a/jupyter-scipy/tests/test_imports.py
+++ b/jupyter-scipy/tests/test_imports.py
@@ -3,24 +3,21 @@
 # See LICENSE file for licensing details.
 #
 #
-from pathlib import Path
-
 import os
 import subprocess
-import yaml
+
+from charmed_kubeflow_chisme.rock import CheckRock
 
 
 def main():
     """Test running container and imports."""
-    rock = yaml.safe_load(Path("rockcraft.yaml").read_text())
-    name = rock["name"]
-    rock_version = rock["version"]
-    arch = list(rock["platforms"].keys())[0]
-    rock_image = f"{name}_{rock_version}_{arch}"
+    check_rock = CheckRock("rockcraft.yaml")
+    rock_image = check_rock.get_name()
+    rock_version = check_rock.get_version()
     LOCAL_ROCK_IMAGE = f"{rock_image}:{rock_version}"
     
     print(f"Running command in {LOCAL_ROCK_IMAGE}")
-    script_command = ["bash", "-c", "export PYTHONPATH=$PYTHONPATH:/opt/conda/lib/python3.8/site-packages/keras/api/keras/wrappers/:/opt/conda/lib/python3.8/site-packages/:/opt/conda/lib/python3.8/site-packages/google/protobuf && python3 /home/jovyan/imports.py"]
+    script_command = ["bash", "-c", "export HOME=/home/jovyan && export PATH=/opt/conda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin && PYTHONPATH=/opt/conda/lib/python3.11/site-packages/  python3.11 /home/jovyan/imports.py"]
     pwd = os.getcwd()
     output = subprocess.run(["docker", "run", "-v", f"{pwd}/tests/:/home/jovyan", LOCAL_ROCK_IMAGE, "exec", "pebble", "exec"] + script_command, stdout=subprocess.PIPE).stdout.decode('utf-8')
     assert "PASSED" in output

--- a/jupyter-scipy/tests/test_rock.py
+++ b/jupyter-scipy/tests/test_rock.py
@@ -1,26 +1,22 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2025 Canonical Ltd.
 # See LICENSE file for licensing details.
 #
 #
-from pathlib import Path
-
 import pytest
 import subprocess
-import yaml
-from pytest_operator.plugin import OpsTest
+
+from charmed_kubeflow_chisme.rock import CheckRock
 
 @pytest.mark.abort_on_fail
-def test_rock(ops_test: OpsTest):
+def test_rock():
     """Test rock."""
-    rock = yaml.safe_load(Path("rockcraft.yaml").read_text())
-    name = rock["name"]
-    rock_version = rock["version"]
-    arch = list(rock["platforms"].keys())[0]
-    rock_image = f"{name}_{rock_version}_{arch}"
+    check_rock = CheckRock("rockcraft.yaml")
+    rock_image = check_rock.get_name()
+    rock_version = check_rock.get_version()
+    rock_services = check_rock.get_services()
     LOCAL_ROCK_IMAGE = f"{rock_image}:{rock_version}"
 
     # verify rock service
-    rock_services = rock["services"]
     assert rock_services["jupyter"]
     assert rock_services["jupyter"]["startup"] == "enabled"
 

--- a/jupyter-scipy/tox.ini
+++ b/jupyter-scipy/tox.ini
@@ -1,8 +1,9 @@
-# Copyright 2022 Canonical Ltd.
+# Copyright 2025 Canonical Ltd.
 # See LICENSE file for licensing details.
 [tox]
 skipsdist = True
 skip_missing_interpreters = True
+envlist = pack, export-to-docker, sanity, integration
 
 [testenv]
 setenv =
@@ -12,29 +13,47 @@ setenv =
     CHARM_BRANCH=main
     LOCAL_CHARM_DIR=charm_repo
 
-[testenv:unit]
+[testenv:pack]
+passenv = *
+allowlist_externals =
+    rockcraft
+commands =
+    rockcraft pack
+
+[testenv:export-to-docker]
 passenv = *
 allowlist_externals =
     bash
-    tox
-    rockcraft
-deps =
-    charmed-kubeflow-chisme
-    juju<4.0
-    pytest
-    pytest-operator
-    tenacity
-    ops
+	rockcraft
+    yq
 commands =
-    # build and pack rock
-    rockcraft pack
+    # pack rock and export to docker
     bash -c 'NAME=$(yq eval .name rockcraft.yaml) && \
              VERSION=$(yq eval .version rockcraft.yaml) && \
-             ARCH=$(yq eval -r ".platforms | keys" rockcraft.yaml | cut -d" " -f2) \
-             ROCK="$\{NAME\}_$\{VERSION\}_$\{ARCH\}" && \
-             sudo skopeo --insecure-policy copy oci-archive:$ROCK.rock docker-daemon:$ROCK:$VERSION && \
-             docker save $ROCK > $ROCK.tar'
+             ARCH=$(yq eval ".platforms | keys | .[0]" rockcraft.yaml) && \
+             ROCK="$\{NAME\}_$\{VERSION\}_$\{ARCH\}.rock" && \
+             DOCKER_IMAGE=$NAME:$VERSION && \
+             echo "Exporting $ROCK to docker as $DOCKER_IMAGE" && \
+             rockcraft.skopeo --insecure-policy copy oci-archive:$ROCK docker-daemon:$DOCKER_IMAGE'
+
+[testenv:sanity]
+passenv = *
+deps =
+    pytest
+    charmed-kubeflow-chisme
+    PyYaml
+    requests
+    tenacity
+commands =
     # run rock tests
     pytest -v --tb native --show-capture=all --log-cli-level=INFO {posargs} {toxinidir}/tests
     python {toxinidir}/tests/test_imports.py
     python {toxinidir}/tests/test_access.py
+
+[testenv:integration]
+passenv = *
+allowlist_externals =
+    echo
+commands =
+    # TODO: Implement integration tests here
+    echo "WARNING: This is a placeholder test - no test is implemented here."


### PR DESCRIPTION
Closes: https://warthogs.atlassian.net/browse/KF-6997

Major changes in upstream:
- Version updates basically in every components
- User and group revamp
- Jupyter initialisation procedure

Other changes:
- I have changed the tests in the rock with the same approach we use in different rocks

**How to review**
- You can run each tox environment to pack export to docker and to run the sanity tests (sanity tests are testing also that the jupyter lab is accessible).
- You can also run the server locally with 
```
docker run -p 8888:8888 misohu/jupyter-scipy:1.10.0 exec /opt/conda/bin/jupyter lab --notebook-dir="/home/jovyan" --ip=0.0.0.0 --no-browser --port=8888 --ServerApp.token="" --ServerApp.password="" --ServerApp.allow_origin="*" --ServerApp.base_url="/" --ServerApp.authenticate_prometheus=False 
```

After that you can access the server at http://localhost:8888/

**Kubeflow integration**
I also successfully deployed the rock with current charmed kubeflow `latest/stable`. 
![image](https://github.com/user-attachments/assets/edad7bee-1be9-4d84-934b-1d82d6614bad)
