### PR TITLE
chore: update `centraldashboard` rock to `v1.10.0-rc.0`

### DIFF
--- a/centraldashboard/rockcraft.yaml
+++ b/centraldashboard/rockcraft.yaml
@@ -1,10 +1,10 @@
-# Dockerfile https://github.com/kubeflow/kubeflow/blob/v1.9.0/components/centraldashboard/Dockerfile
+# Dockerfile https://github.com/kubeflow/kubeflow/blob/v1.10.0-rc.0/components/centraldashboard/Dockerfile
 name: centraldashboard
 summary: Kubeflow Landing Page
 description: |
   This component serves as the landing page and central dashboard for Kubeflow deployments.
   It provides a jump-off point to all other facets of the platform.
-version: "1.9.0"
+version: "1.10.0-rc.0"
 license: Apache-2.0
 base: ubuntu@22.04
 platforms:
@@ -33,7 +33,7 @@ parts:
     source: https://github.com/kubeflow/kubeflow
     source-subdir: components/centraldashboard
     source-type: git
-    source-tag: v1.9.0 # upstream branch
+    source-tag: v1.10.0-rc.0 # upstream branch
     build-snaps:
       - node/16/stable
     build-packages:
@@ -47,9 +47,9 @@ parts:
       - nodejs
       - npm
     build-environment:
-      - CHROME_BIN: /usr/bin/chromium-browser
-      - PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: true
-      - BUILD_VERSION: "1.9"
+      - CHROME_BIN: "/usr/bin/chromium-browser"
+      - PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: "true"
+      - BUILD_VERSION: "v1.10.0-rc.0"
     stage-packages:
       - nodejs
       - npm

--- a/centraldashboard/tox.ini
+++ b/centraldashboard/tox.ini
@@ -21,7 +21,7 @@ commands =
 passenv = *
 allowlist_externals =
     bash
-    skopeo
+    rockcraft
     yq
 commands =
     # export already packed rock to docker
@@ -31,7 +31,7 @@ commands =
              ROCK="$\{NAME\}_$\{VERSION\}_$\{ARCH\}.rock" && \
              DOCKER_IMAGE=$NAME:$VERSION && \\
              echo "Exporting $ROCK to docker as $DOCKER_IMAGE" && \
-             skopeo --insecure-policy copy oci-archive:$ROCK docker-daemon:$DOCKER_IMAGE'
+             rockcraft.skopeo --insecure-policy copy oci-archive:$ROCK docker-daemon:$DOCKER_IMAGE'
 
 [testenv:sanity]
 passenv = *


### PR DESCRIPTION
Closes https://warthogs.atlassian.net/browse/KF-6803

## Testing
Run the upstream image to compare to the rock:
```
docker run docker.io/kubeflownotebookswg/centraldashboard:v1.10.0-rc.0

> kubeflow-centraldashboard@0.0.2 start
> npm run serve


> kubeflow-centraldashboard@0.0.2 serve
> node dist/server.js

Initializing Kubernetes configuration
Unable to fetch Nodes Error: connect ECONNREFUSED 127.0.0.1:8080
    at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1278:16) {
  errno: -111,
  code: 'ECONNREFUSED',
  syscall: 'connect',
  address: '127.0.0.1',
  port: 8080
}
Unable to fetch Application information: Error: connect ECONNREFUSED 127.0.0.1:8080
    at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1278:16) {
  errno: -111,
  code: 'ECONNREFUSED',
  syscall: 'connect',
  address: '127.0.0.1',
  port: 8080
}
Unable to fetch Nodes Error: connect ECONNREFUSED 127.0.0.1:8080
    at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1278:16) {
  errno: -111,
  code: 'ECONNREFUSED',
  syscall: 'connect',
  address: '127.0.0.1',
  port: 8080
}
"other" is not a supported platform for Metrics
Using Profiles service at http://profiles-kfam.kubeflow:8081/kfam
Enabling the metrics collections to be accessible in the path `/prometheus/metrics`.
Server listening on port http://localhost:8082 (in production mode)
```
Run the rock and view pebble logs:
```
_daemon_@f284af4d408a:/$ pebble logs
2025-02-18T13:24:03.267Z [kubeflow-dashboard] 
2025-02-18T13:24:04.383Z [kubeflow-dashboard] Initializing Kubernetes configuration
2025-02-18T13:24:04.407Z [kubeflow-dashboard] Unable to fetch Nodes Error: connect ECONNREFUSED 127.0.0.1:8080
2025-02-18T13:24:04.407Z [kubeflow-dashboard]     at TCPConnectWrap.afterConnect [as oncomplete] (net.js:1138:16) {
2025-02-18T13:24:04.407Z [kubeflow-dashboard]   errno: 'ECONNREFUSED',
2025-02-18T13:24:04.407Z [kubeflow-dashboard]   code: 'ECONNREFUSED',
2025-02-18T13:24:04.407Z [kubeflow-dashboard]   syscall: 'connect',
2025-02-18T13:24:04.407Z [kubeflow-dashboard]   address: '127.0.0.1',
2025-02-18T13:24:04.407Z [kubeflow-dashboard]   port: 8080
2025-02-18T13:24:04.407Z [kubeflow-dashboard] }
2025-02-18T13:24:04.407Z [kubeflow-dashboard] Unable to fetch Application information: Error: connect ECONNREFUSED 127.0.0.1:8080
2025-02-18T13:24:04.407Z [kubeflow-dashboard]     at TCPConnectWrap.afterConnect [as oncomplete] (net.js:1138:16) {
2025-02-18T13:24:04.407Z [kubeflow-dashboard]   errno: 'ECONNREFUSED',
2025-02-18T13:24:04.407Z [kubeflow-dashboard]   code: 'ECONNREFUSED',
2025-02-18T13:24:04.407Z [kubeflow-dashboard]   syscall: 'connect',
2025-02-18T13:24:04.407Z [kubeflow-dashboard]   address: '127.0.0.1',
2025-02-18T13:24:04.407Z [kubeflow-dashboard]   port: 8080
2025-02-18T13:24:04.407Z [kubeflow-dashboard] }
2025-02-18T13:24:04.411Z [kubeflow-dashboard] Unable to fetch Nodes Error: connect ECONNREFUSED 127.0.0.1:8080
2025-02-18T13:24:04.411Z [kubeflow-dashboard]     at TCPConnectWrap.afterConnect [as oncomplete] (net.js:1138:16) {
2025-02-18T13:24:04.411Z [kubeflow-dashboard]   errno: 'ECONNREFUSED',
2025-02-18T13:24:04.411Z [kubeflow-dashboard]   code: 'ECONNREFUSED',
2025-02-18T13:24:04.411Z [kubeflow-dashboard]   syscall: 'connect',
2025-02-18T13:24:04.411Z [kubeflow-dashboard]   address: '127.0.0.1',
2025-02-18T13:24:04.411Z [kubeflow-dashboard]   port: 8080
2025-02-18T13:24:04.411Z [kubeflow-dashboard] }
2025-02-18T13:24:04.411Z [kubeflow-dashboard] "other" is not a supported platform for Metrics
2025-02-18T13:24:04.411Z [kubeflow-dashboard] Using Profiles service at http://profiles-kfam.kubeflow:8081/kfam
2025-02-18T13:24:04.411Z [kubeflow-dashboard] Enabling the metrics collections to be accessible in the path `/prometheus/metrics`.
2025-02-18T13:24:04.421Z [kubeflow-dashboard] Server listening on port http://localhost:8082 (in production mode)
```