### PR TITLE
chore: update `notebook-controller rock` to `1.10.0-rc.0`

### DIFF
--- a/notebook-controller/rockcraft.yaml
+++ b/notebook-controller/rockcraft.yaml
@@ -1,10 +1,10 @@
-# Source https://github.com/kubeflow/kubeflow/blob/v1.9.0/components/notebook-controller/Dockerfile
+# Source https://github.com/kubeflow/kubeflow/blob/v1.10.0-rc.0/components/notebook-controller/Dockerfile
 name: notebook-controller
 summary: An image for Jupyter notebook controller
 description: |
   This image is used as part of the Charmed Kubeflow product. The controller allows users to
   create a custom resource "Notebook" (jupyter notebook).
-version: "1.9.0"
+version: "1.10.0-rc.0"
 license: Apache-2.0
 base: ubuntu@22.04
 services:
@@ -30,7 +30,7 @@ parts:
     plugin: go
     source: https://github.com/kubeflow/kubeflow
     source-type: git
-    source-tag: v1.9.0
+    source-tag: v1.10.0-rc.0
     build-snaps:
       - go/1.17/stable
     build-packages:

--- a/notebook-controller/tox.ini
+++ b/notebook-controller/tox.ini
@@ -24,7 +24,7 @@ commands =
 passenv = *
 allowlist_externals =
     bash
-    skopeo
+    rockcraft
     yq
 commands =
     # export rock to docker
@@ -34,7 +34,7 @@ commands =
              ROCK="$\{NAME\}_$\{VERSION\}_$\{ARCH\}.rock" && \
              DOCKER_IMAGE=$NAME:$VERSION && \
              echo "Exporting $ROCK to docker as $DOCKER_IMAGE" && \
-             skopeo --insecure-policy copy oci-archive:$ROCK docker-daemon:$DOCKER_IMAGE'
+             rockcraft.skopeo --insecure-policy copy oci-archive:$ROCK docker-daemon:$DOCKER_IMAGE'
 
 [testenv:sanity]
 passenv = *


### PR DESCRIPTION
Closes https://warthogs.atlassian.net/browse/KF-6836

## Testing
Run the upstream image to compare to the rock:
```
docker run docker.io/kubeflownotebookswg/notebook-controller:v1.10.0-rc.0
1.73996405923178e+09    ERROR   controller-runtime.client.config        unable to get kubeconfig        {"error": "invalid configuration: no configuration has been provided, try setting KUBERNETES_MASTER environment variable", "errorCauses": [{"error": "no configuration has been provided, try setting KUBERNETES_MASTER environment variable"}]}
sigs.k8s.io/controller-runtime/pkg/client/config.GetConfigOrDie
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.11.0/pkg/client/config/config.go:153
main.main
        /workspace/notebook-controller/main.go:78
runtime.main
        /usr/local/go/src/runtime/proc.go:255
```
Run the rock and view pebble logs from running container:
```
root@bdb2b23472d0:/# pebble logs
2025-02-19T11:21:45.200Z [jupyter-controller] runtime.main
2025-02-19T11:21:45.200Z [jupyter-controller]   /snap/go/9949/src/runtime/proc.go:255
2025-02-19T11:21:46.257Z [jupyter-controller] 1.739964106257242e+09ERROR   controller-runtime.client.config unable to get kubeconfig {"error": "invalid configuration: no configuration has been provided, try setting KUBERNETES_MASTER environment variable", "errorCauses": [{"error": "no configuration has been provided, try setting KUBERNETES_MASTER environment variable"}]}
2025-02-19T11:21:46.257Z [jupyter-controller] sigs.k8s.io/controller-runtime/pkg/client/config.GetConfigOrDie
2025-02-19T11:21:46.257Z [jupyter-controller]   /root/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.11.0/pkg/client/config/config.go:153
2025-02-19T11:21:46.257Z [jupyter-controller] main.main
2025-02-19T11:21:46.257Z [jupyter-controller]   /root/parts/notebook-controller/src/components/notebook-controller/main.go:78
2025-02-19T11:21:46.257Z [jupyter-controller] runtime.main
2025-02-19T11:21:46.257Z [jupyter-controller]   /snap/go/9949/src/runtime/proc.go:255
```