### PR TITLE
chore: update `admission-webhook` rock to 1.10.0-rc.0

### DIFF
--- a/admission-webhook/rockcraft.yaml
+++ b/admission-webhook/rockcraft.yaml
@@ -1,7 +1,7 @@
-# From https://github.com/kubeflow/kubeflow/blob/v1.9-branch/components/admission-webhook/Dockerfile
+# From https://github.com/kubeflow/kubeflow/blob/v1.10.0-rc.0/components/admission-webhook/Dockerfile
 name: admission-webhook
-base: ubuntu@20.04
-version: v1.9.0
+base: ubuntu@22.04
+version: 1.10.0-rc.0
 summary: An image for Kubeflow's admission-webhook
 description: |
   Admission webhook controller in general, intercepts requests to the Kubernetes API server, 
@@ -37,7 +37,7 @@ parts:
     build-snaps:
       - go/1.21/stable
     source: https://github.com/kubeflow/kubeflow.git
-    source-tag: v1.9-branch
+    source-tag: v1.10.0-rc.0
     build-environment:
       - CGO_ENABLED: 0
       - GOOS: linux

--- a/admission-webhook/tox.ini
+++ b/admission-webhook/tox.ini
@@ -21,7 +21,7 @@ commands =
 passenv = *
 allowlist_externals =
     bash
-    skopeo
+    rockcraft
     yq
 commands =
     # export rock to docker
@@ -31,7 +31,7 @@ commands =
              ROCK="$\{NAME\}_$\{VERSION\}_$\{ARCH\}.rock" && \
              DOCKER_IMAGE=$NAME:$VERSION && \
              echo "Exporting $ROCK to docker as $DOCKER_IMAGE" && \
-             skopeo --insecure-policy copy oci-archive:$ROCK docker-daemon:$DOCKER_IMAGE'
+             rockcraft.skopeo --insecure-policy copy oci-archive:$ROCK docker-daemon:$DOCKER_IMAGE'
 
 [testenv:sanity]
 passenv = *


### PR DESCRIPTION
Closes https://warthogs.atlassian.net/browse/KF-6800

## Testing
Run the upstream image:
```
docker run docker.io/kubeflownotebookswg/poddefaults-webhook:v1.10.0-rc.0
Unable to find image 'kubeflownotebookswg/poddefaults-webhook:v1.10.0-rc.0' locally
v1.10.0-rc.0: Pulling from kubeflownotebookswg/poddefaults-webhook
3ddae62150f2: Pull complete 
7b5a55846184: Pull complete 
Digest: sha256:ca91fccaa463ca0a7ad42ae682b258aa6b5306adbe4af0444ed2876faa1a3862
Status: Downloaded newer image for kubeflownotebookswg/poddefaults-webhook:v1.10.0-rc.0
F0219 12:44:50.321653       1 config.go:46] config=main.Config{CertFile:"/etc/webhook/certs/cert.pem", KeyFile:"/etc/webhook/certs/key.pem"} Error: open /etc/webhook/certs/cert.pem: no such file or directory
```
Run the rock and get the pebble logs:
```
root@67642c5d63a4:/# pebble logs
2025-02-20T08:39:55.812Z [admission-webhook] F0220 08:39:55.812229      15 config.go:46] config=main.Config{CertFile:"/etc/webhook/certs/cert.pem", KeyFile:"/etc/webhook/certs/key.pem"} Error: open /etc/webhook/certs/cert.pem: no such file or directory
```
the logs are the same as the upstream image