### PR TITLE
chore: Update pvcviewer-controller rock to 1.10-rc.1

### DIFF
--- a/pvcviewer-controller/rockcraft.yaml
+++ b/pvcviewer-controller/rockcraft.yaml
@@ -50,12 +50,4 @@ parts:
       bin/pvc-viewer: "/manager"
     prime:
       - manager
-      
-  non-root-user:
-    plugin: nil
-    after: [pvcviewer-operator]
-    overlay-script: |
-      # Create a user in the $CRAFT_OVERLAY chroot
-      groupadd -R $CRAFT_OVERLAY -g 1001 ubuntu
-      useradd -R $CRAFT_OVERLAY -M -r -u 1001 -g ubuntu ubuntu
 

--- a/pvcviewer-controller/rockcraft.yaml
+++ b/pvcviewer-controller/rockcraft.yaml
@@ -8,6 +8,7 @@ description: |
 version: "1.10.0-rc.1"
 license: Apache-2.0
 base: ubuntu@22.04
+run-user: _daemon_
 platforms:
   amd64:
 

--- a/pvcviewer-controller/rockcraft.yaml
+++ b/pvcviewer-controller/rockcraft.yaml
@@ -1,14 +1,13 @@
-# Source https://github.com/kubeflow/kubeflow/blob/v1.9.0/components/pvcviewer-controller/Dockerfile
+# Source https://github.com/kubeflow/kubeflow/blob/v1.10.0-rc.1/components/pvcviewer-controller/Dockerfile
 
 name: pvcviewer-controller
 summary: An image for PVC viewer controller
 description: |
   This image is used as part of the Kubeflow ecosystem. The controller allows users to
   manage and view Persistent Volume Claims (PVCs) in the cluster.
-version: "1.9.0"
+version: "1.10.0-rc.1"
 license: Apache-2.0
 base: ubuntu@22.04
-run-user: _daemon_
 platforms:
   amd64:
 
@@ -34,7 +33,7 @@ parts:
     source-type: git    
     source: https://github.com/kubeflow/kubeflow.git
     source-depth: 1
-    source-tag: v1.9.0
+    source-tag: v1.10.0-rc.1
     source-subdir: components/pvcviewer-controller/    
     build-snaps:
       - go/1.22/stable

--- a/pvcviewer-controller/tox.ini
+++ b/pvcviewer-controller/tox.ini
@@ -21,7 +21,7 @@ commands =
 passenv = *
 allowlist_externals =
     bash
-    skopeo
+    rockcraft
     yq
 commands =
 # export rock to docker
@@ -31,7 +31,7 @@ commands =
     ROCK="$\{NAME\}_$\{VERSION\}_$\{ARCH\}.rock" && \
     DOCKER_IMAGE=$NAME:$VERSION && \
     echo "Exporting $ROCK to docker as $DOCKER_IMAGE" && \
-    skopeo --insecure-policy copy oci-archive:$ROCK docker-daemon:$DOCKER_IMAGE'
+    rockcraft.skopeo --insecure-policy copy oci-archive:$ROCK docker-daemon:$DOCKER_IMAGE'
 
 [testenv:sanity]
 passenv = *


### PR DESCRIPTION
Small note on removing `run-user: _daemon`: There is an issue when running pebble as `_daemon_` and running a service as a non-root user, where we get an error similar to this:
```
2025-02-10T14:08:30.863Z [pebble] Change 1 task (Start service "myapp") failed: cannot start service: fork/exec /bin/whoami: operation not permitted
```
For example, we encountered this during the creation of the `torchserve-kfs` rock in the `kserve-rocks` repository. The suggestion from the rockcraft team was to remove `run-user`, as mentioned in [this comment](https://github.com/canonical/kserve-rocks/pull/106#issuecomment-2648921069)

## How to ensure that it is working
First pull and run the upstream image:
```
docker pull kubeflownotebookswg/pvcviewer-controller:v1.10.0-rc.1
docker run --rm -it kubeflownotebookswg/pvcviewer-controller:v1.10.0-rc.1
```
You should see output similar to:
```
2025-02-28T11:43:48Z	ERROR	controller-runtime.client.config	unable to load in-cluster config	{"error": "unable to load in-cluster configuration, KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined"}
sigs.k8s.io/controller-runtime/pkg/client/config.loadConfig.func1
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.17.3/pkg/client/config/config.go:133
sigs.k8s.io/controller-runtime/pkg/client/config.loadConfig
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.17.3/pkg/client/config/config.go:155
sigs.k8s.io/controller-runtime/pkg/client/config.GetConfigWithContext
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.17.3/pkg/client/config/config.go:97
sigs.k8s.io/controller-runtime/pkg/client/config.GetConfig
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.17.3/pkg/client/config/config.go:77
sigs.k8s.io/controller-runtime/pkg/client/config.GetConfigOrDie
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.17.3/pkg/client/config/config.go:175
main.main
	/workspace/main.go:72
runtime.main
	/usr/local/go/src/runtime/proc.go:271
2025-02-28T11:43:48Z	ERROR	controller-runtime.client.config	unable to get kubeconfig	{"error": "invalid configuration: no configuration has been provided, try setting KUBERNETES_MASTER environment variable", "errorCauses": [{"error": "no configuration has been provided, try setting KUBERNETES_MASTER environment variable"}]}
sigs.k8s.io/controller-runtime/pkg/client/config.GetConfigOrDie
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.17.3/pkg/client/config/config.go:177
main.main
	/workspace/main.go:72
runtime.main
	/usr/local/go/src/runtime/proc.go:271
```

Then pack, export to docker, and run the rock:
```
rockcraft pack
tox -e export-to-docker
docker run --rm -it <image-id>
```

Run bash in this container from a different terminal window, and run pebble logs:
```
docker ps
docker exec -it <containerid> bash
pebble logs
```
You should see the same output :)