### PR TITLE
chore: upgrade kfam 1.10.0-rc.0 -> 1.10.0-rc.1

### DIFF
--- a/kfam/rockcraft.yaml
+++ b/kfam/rockcraft.yaml
@@ -1,11 +1,11 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
-# Constructed from https://github.com/kubeflow/kubeflow/blob/v1.10.0-rc.0/components/access-management/Dockerfile
+# Constructed from https://github.com/kubeflow/kubeflow/blob/v1.10.0-rc.1/components/access-management/Dockerfile
 
 name: kfam
 summary: Kubeflow Access Management API
 description: Kubeflow Access Management API provides fine-grain user-namespace level access control.
-version: "1.10.0-rc.0"
+version: "1.10.0-rc.1"
 license: Apache-2.0
 base: ubuntu@22.04
 
@@ -33,7 +33,7 @@ parts:
     source: https://github.com/kubeflow/kubeflow.git
     source-subdir: components/access-management
     source-type: git
-    source-tag: v1.10.0-rc.0
+    source-tag: v1.10.0-rc.1
     build-environment:
       - CGO_ENABLED: 0
       - GOOS: linux


### PR DESCRIPTION
This commit upgrades the kfam rock in preparation for a new release.

Fixes #178

Changes from the Dockerfiles are:

```diff
< FROM gcr.io/distroless/base:latest as serve
---
> FROM gcr.io/distroless/static:nonroot as serve
>
25a27,28
> USER 65532:65532
>
```

But the user shouldn't affect us as we are using a different one.