### PR TITLE
chore: upgrade tensorboards-web-app 1.10.0-rc.0 -> 1.10.0-rc.1

### DIFF
--- a/tensorboards-web-app/rockcraft.yaml
+++ b/tensorboards-web-app/rockcraft.yaml
@@ -1,10 +1,10 @@
-# Based on https://github.com/kubeflow/kubeflow/blob/v1.10.0-rc.0/components/crud-web-apps/tensorboards/Dockerfile
+# Based on https://github.com/kubeflow/kubeflow/blob/v1.10.0-rc.1/components/crud-web-apps/tensorboards/Dockerfile
 name: tensorboards-web-app
 summary: Tensorboards Web App
 description: |
   This web app is responsible for allowing the user to manipulate tensorboards in their Kubeflow
   cluster.
-version: "1.10.0-rc.0"
+version: "1.10.0-rc.1"
 license: Apache-2.0
 base: ubuntu@22.04
 platforms:
@@ -32,7 +32,7 @@ parts:
     plugin: nil
     source: https://github.com/kubeflow/kubeflow
     source-type: git
-    source-tag: v1.10.0-rc.0
+    source-tag: v1.10.0-rc.1
     source-depth: 1
     build-packages:
       - python3-venv
@@ -54,7 +54,7 @@ parts:
     plugin: nil
     source: https://github.com/kubeflow/kubeflow
     source-type: git
-    source-tag: v1.10.0-rc.0
+    source-tag: v1.10.0-rc.1
     source-depth: 1
     build-snaps:
       - node/16/stable
@@ -76,7 +76,7 @@ parts:
     plugin: nil
     source: https://github.com/kubeflow/kubeflow
     source-type: git
-    source-tag: v1.10.0-rc.0
+    source-tag: v1.10.0-rc.1
     source-depth: 1
     build-snaps:
       - node/16/stable
@@ -104,7 +104,7 @@ parts:
     plugin: nil
     source: https://github.com/kubeflow/kubeflow
     source-type: git
-    source-tag: v1.10.0-rc.0
+    source-tag: v1.10.0-rc.1
     source-depth: 1
     build-packages:
       - python3-venv
@@ -128,7 +128,7 @@ parts:
   gunicorn:
     plugin: python
     source: https://github.com/kubeflow/kubeflow.git
-    source-tag: v1.10.0-rc.0
+    source-tag: v1.10.0-rc.1
     source-depth: 1
     python-requirements:
     - components/crud-web-apps/tensorboards/backend/requirements.txt


### PR DESCRIPTION
This commit upgrades the tensorboards-web-app rock in preparation for a new release.

Fixes #183

No changes in upstream Dockerfiles, just tag.