### PR TITLE
chore: upgrade notebook rocks to v1.10.0

### DIFF
--- a/jupyter-pytorch-full/rockcraft.yaml
+++ b/jupyter-pytorch-full/rockcraft.yaml
@@ -1,8 +1,8 @@
 # Based on the following Dockerfiles:
-# https://github.com/kubeflow/kubeflow/blob/v1.10.0-rc.1/components/example-notebook-servers/base/Dockerfile
-# https://github.com/kubeflow/kubeflow/blob/v1.10.0-rc.1/components/example-notebook-servers/jupyter/Dockerfile
-# https://github.com/kubeflow/kubeflow/blob/v1.10.0-rc.1/components/example-notebook-servers/jupyter-pytorch/Dockerfile
-# https://github.com/kubeflow/kubeflow/blob/v1.10.0-rc.1/components/example-notebook-servers/jupyter-pytorch-full/Dockerfile
+# https://github.com/kubeflow/kubeflow/blob/v1.10.0/components/example-notebook-servers/base/Dockerfile
+# https://github.com/kubeflow/kubeflow/blob/v1.10.0/components/example-notebook-servers/jupyter/Dockerfile
+# https://github.com/kubeflow/kubeflow/blob/v1.10.0/components/example-notebook-servers/jupyter-pytorch/Dockerfile
+# https://github.com/kubeflow/kubeflow/blob/v1.10.0/components/example-notebook-servers/jupyter-pytorch-full/Dockerfile
 name: jupyter-pytorch-full
 summary: An image for using Jupyter & PyTorch on CPUs
 description: |
@@ -12,7 +12,7 @@ description: |
 
   Both PyTorch and Jupyter are installed in Conda environment, which is
   automatically activated.
-version: "v1.10.0-rc.1"
+version: "v1.10.0"
 license: Apache-2.0
 base: ubuntu@22.04
 run-user: _daemon_
@@ -101,7 +101,7 @@ parts:
     plugin: nil
     source: https://github.com/kubeflow/kubeflow
     source-type: git
-    source-tag: v1.10.0-rc.1
+    source-tag: v1.10.0
     build-packages:
       - lsb-release
       - wget

--- a/jupyter-scipy/CONTRIBUTING.md
+++ b/jupyter-scipy/CONTRIBUTING.md
@@ -1,16 +1,16 @@
-# Contributing to Jupyter-SciPy Rock
+# Contributing to Jupyter-SciPy rock
 
 ## Overview
-This Rock is built based on three upstream Dockerfiles from the Kubeflow project:
+This rock is built based on three upstream Dockerfiles from the Kubeflow project:
 
 - [Base Dockerfile](https://github.com/kubeflow/kubeflow/blob/v1.10.0/components/example-notebook-servers/base/Dockerfile)
 - [Jupyter Dockerfile](https://github.com/kubeflow/kubeflow/blob/v1.10.0/components/example-notebook-servers/jupyter/Dockerfile)
 - [Jupyter-SciPy Dockerfile](https://github.com/kubeflow/kubeflow/blob/v1.10.0/components/example-notebook-servers/jupyter-scipy/Dockerfile)
 
-If you are updating this Rock, ensure you check the above Dockerfiles from top to bottom to track any modifications.
+If you are updating this rock, ensure you check the above Dockerfiles from top to bottom to track any modifications.
 
 ## Architecture and Scope
-The upstream Dockerfiles use `s6` to build images for different architectures, including ARM support. However, for this Rock, we are skipping `s6` because we are not building for ARM.
+The upstream Dockerfiles use `s6` to build images for different architectures, including ARM support. However, for this rock, we are skipping `s6` because we are not building for ARM.
 
 Additionally, we are skipping the following parts from the upstream Dockerfiles:
 - [`base/Dockerfile#L73`](https://github.com/kubeflow/kubeflow/blob/v1.10.0/components/example-notebook-servers/base/Dockerfile#L73)
@@ -34,8 +34,8 @@ We are also omitting environment variables related to `s6`.
   cat /proc/<process_id>/environ | tr '\0' '\n'
   ```
 
-## Extracting the Command for the Rock
-The command used in the Rock's service section is derived by running the upstream Docker image and inspecting the active processes.
+## Extracting the Command for the rock
+The command used in the rock's service section is derived by running the upstream Docker image and inspecting the active processes.
 To extract the correct command:
 
 ```sh
@@ -47,8 +47,8 @@ docker exec -ti <container_id> bash
 Alternatively, you can check the upstream command file:
 [Run Script](https://github.com/kubeflow/kubeflow/blob/v1.10.0/components/example-notebook-servers/jupyter/s6/services.d/jupyterlab/run)
 
-## Service Command Execution in Rock
-The command in the service definition must be wrapped with `bash -c`. This ensures that when the Rock is executed in a pod, environment variables such as `HOME` and `NB_PREFIX` are dynamically resolved. These variables should **not** be explicitly set in the service section, as their values depend on the specific notebook instance.
+## Service Command Execution in rock
+The command in the service definition must be wrapped with `bash -c`. This ensures that when the rock is executed in a pod, environment variables such as `HOME` and `NB_PREFIX` are dynamically resolved. These variables should **not** be explicitly set in the service section, as their values depend on the specific notebook instance.
 
 ### Example Service Command:
 ```yaml
@@ -56,12 +56,12 @@ command: bash -c './jupyter lab --notebook-dir=${HOME} --ip=0.0.0.0 --no-browser
 ```
 
 ## Preinstalling MLflow Library
-MLflow must be preinstalled in the Rock. The latest version can be checked [here](https://github.com/canonical/mlflow-operator/blob/main/metadata.yaml#L18).
+MLflow must be preinstalled in the rock. The latest version can be checked [here](https://github.com/canonical/mlflow-operator/blob/main/metadata.yaml#L18).
 
 The upstream Docker image does **not** install MLflow by default. This is required for integration purposes within the Charmed Kubeflow ecosystem.
 
-## Running the Rock Locally
-To build the Rock locally, use:
+## Running the rock Locally
+To build the rock locally, use:
 ```sh
 tox -e pack
 tox -e export-to-docker

--- a/jupyter-scipy/CONTRIBUTING.md
+++ b/jupyter-scipy/CONTRIBUTING.md
@@ -3,9 +3,9 @@
 ## Overview
 This Rock is built based on three upstream Dockerfiles from the Kubeflow project:
 
-- [Base Dockerfile](https://github.com/kubeflow/kubeflow/blob/v1.10.0-rc.0/components/example-notebook-servers/base/Dockerfile)
-- [Jupyter Dockerfile](https://github.com/kubeflow/kubeflow/blob/v1.10.0-rc.0/components/example-notebook-servers/jupyter/Dockerfile)
-- [Jupyter-SciPy Dockerfile](https://github.com/kubeflow/kubeflow/blob/v1.10.0-rc.0/components/example-notebook-servers/jupyter-scipy/Dockerfile)
+- [Base Dockerfile](https://github.com/kubeflow/kubeflow/blob/v1.10.0/components/example-notebook-servers/base/Dockerfile)
+- [Jupyter Dockerfile](https://github.com/kubeflow/kubeflow/blob/v1.10.0/components/example-notebook-servers/jupyter/Dockerfile)
+- [Jupyter-SciPy Dockerfile](https://github.com/kubeflow/kubeflow/blob/v1.10.0/components/example-notebook-servers/jupyter-scipy/Dockerfile)
 
 If you are updating this Rock, ensure you check the above Dockerfiles from top to bottom to track any modifications.
 
@@ -13,8 +13,8 @@ If you are updating this Rock, ensure you check the above Dockerfiles from top t
 The upstream Dockerfiles use `s6` to build images for different architectures, including ARM support. However, for this Rock, we are skipping `s6` because we are not building for ARM.
 
 Additionally, we are skipping the following parts from the upstream Dockerfiles:
-- [`base/Dockerfile#L73`](https://github.com/kubeflow/kubeflow/blob/v1.10.0-rc.0/components/example-notebook-servers/base/Dockerfile#L73)
-- [`base/Dockerfile#L129`](https://github.com/kubeflow/kubeflow/blob/v1.10.0-rc.0/components/example-notebook-servers/base/Dockerfile#L129)
+- [`base/Dockerfile#L73`](https://github.com/kubeflow/kubeflow/blob/v1.10.0/components/example-notebook-servers/base/Dockerfile#L73)
+- [`base/Dockerfile#L129`](https://github.com/kubeflow/kubeflow/blob/v1.10.0/components/example-notebook-servers/base/Dockerfile#L129)
 
 We are also omitting environment variables related to `s6`.
 
@@ -45,7 +45,7 @@ docker exec -ti <container_id> bash
 ```
 
 Alternatively, you can check the upstream command file:
-[Run Script](https://github.com/kubeflow/kubeflow/blob/v1.10.0-rc.0/components/example-notebook-servers/jupyter/s6/services.d/jupyterlab/run)
+[Run Script](https://github.com/kubeflow/kubeflow/blob/v1.10.0/components/example-notebook-servers/jupyter/s6/services.d/jupyterlab/run)
 
 ## Service Command Execution in Rock
 The command in the service definition must be wrapped with `bash -c`. This ensures that when the Rock is executed in a pod, environment variables such as `HOME` and `NB_PREFIX` are dynamically resolved. These variables should **not** be explicitly set in the service section, as their values depend on the specific notebook instance.

--- a/jupyter-scipy/rockcraft.yaml
+++ b/jupyter-scipy/rockcraft.yaml
@@ -1,7 +1,7 @@
 # Based on:
-# https://github.com/kubeflow/kubeflow/blob/v1.10.0-rc.1/components/example-notebook-servers/base/Dockerfile
-# https://github.com/kubeflow/kubeflow/blob/v1.10.0-rc.1/components/example-notebook-servers/jupyter/Dockerfile
-# https://github.com/kubeflow/kubeflow/blob/v1.10.0-rc.1/components/example-notebook-servers/jupyter-scipy/Dockerfile
+# https://github.com/kubeflow/kubeflow/blob/v1.10.0/components/example-notebook-servers/base/Dockerfile
+# https://github.com/kubeflow/kubeflow/blob/v1.10.0/components/example-notebook-servers/jupyter/Dockerfile
+# https://github.com/kubeflow/kubeflow/blob/v1.10.0/components/example-notebook-servers/jupyter-scipy/Dockerfile
 name: jupyter-scipy
 summary: An image for using Jupyter SciPy
 description: |
@@ -11,7 +11,7 @@ description: |
 
   Both SciPy and Jupyter are installed in Conda environment, which is
   automatically activated.
-version: 1.10.0-rc.1
+version: 1.10.0
 license: Apache-2.0
 base: ubuntu@22.04
 run-user: _daemon_
@@ -38,7 +38,7 @@ services:
       LC_ALL: en_US.UTF-8
       PATH: /opt/conda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
       PYTHONPATH: /opt/conda/lib/python3.11/site-packages/
-    # Command source https://github.com/kubeflow/kubeflow/blob/v1.10.0-rc.1/components/example-notebook-servers/jupyter/s6/services.d/jupyterlab/run
+    # Command source https://github.com/kubeflow/kubeflow/blob/v1.10.0/components/example-notebook-servers/jupyter/s6/services.d/jupyterlab/run
     command: bash -c '/opt/conda/bin/jupyter lab --notebook-dir=${HOME} --ip=0.0.0.0 --no-browser --allow-root --port=8888 --ServerApp.token="" --ServerApp.password="" --ServerApp.allow_origin="*" --ServerApp.allow_remote_access=True --ServerApp.base_url=${NB_PREFIX} --ServerApp.authenticate_prometheus=False'
     working-dir: /home/jovyan/
 platforms:
@@ -124,7 +124,7 @@ parts:
     plugin: nil
     source: https://github.com/kubeflow/kubeflow
     source-type: git
-    source-tag: v1.10.0-rc.1
+    source-tag: v1.10.0
     build-packages:
       - lsb-release
       - wget

--- a/jupyter-web-app/rockcraft.yaml
+++ b/jupyter-web-app/rockcraft.yaml
@@ -1,10 +1,10 @@
-# Based on https://github.com/kubeflow/kubeflow/blob/v1.10.0-rc.1/components/crud-web-apps/jupyter/Dockerfile
+# Based on https://github.com/kubeflow/kubeflow/blob/v1.10.0/components/crud-web-apps/jupyter/Dockerfile
 name: jupyter-web-app
 summary: An image for Jupyter UI
 description: |
   This image is used as part of Charmed Kubeflow product. Jupyter UI web application provides
   users with web UI to access and manipulate Jupyter Notebooks in Charmed Kubeflow.
-version: "1.10.0-rc.1"
+version: "1.10.0"
 license: Apache-2.0
 base: ubuntu@22.04
 platforms:
@@ -25,7 +25,7 @@ parts:
     plugin: nil
     source: https://github.com/kubeflow/kubeflow
     source-type: git
-    source-tag: v1.10.0-rc.1
+    source-tag: v1.10.0
     source-depth: 1
     build-packages:
       - python3-venv
@@ -47,7 +47,7 @@ parts:
     plugin: nil
     source: https://github.com/kubeflow/kubeflow
     source-type: git
-    source-tag: v1.10.0-rc.1
+    source-tag: v1.10.0
     source-depth: 1
     build-snaps:
       - node/16/stable
@@ -69,7 +69,7 @@ parts:
     plugin: nil
     source: https://github.com/kubeflow/kubeflow
     source-type: git
-    source-tag: v1.10.0-rc.1
+    source-tag: v1.10.0
     source-depth: 1
     build-snaps:
       - node/16/stable
@@ -94,7 +94,7 @@ parts:
   gunicorn:
     plugin: python
     source: https://github.com/kubeflow/kubeflow.git
-    source-tag: v1.10.0-rc.1
+    source-tag: v1.10.0
     source-depth: 1
     python-requirements:
     - components/crud-web-apps/jupyter/backend/requirements.txt
@@ -106,7 +106,7 @@ parts:
     plugin: nil
     source: https://github.com/kubeflow/kubeflow
     source-type: git
-    source-tag: v1.10.0-rc.1
+    source-tag: v1.10.0
     source-depth: 1
     build-packages:
       - python3-venv

--- a/notebook-controller/rockcraft.yaml
+++ b/notebook-controller/rockcraft.yaml
@@ -1,10 +1,10 @@
-# Source https://github.com/kubeflow/kubeflow/blob/v1.10.0-rc.1/components/notebook-controller/Dockerfile
+# Source https://github.com/kubeflow/kubeflow/blob/v1.10.0/components/notebook-controller/Dockerfile
 name: notebook-controller
 summary: An image for Jupyter notebook controller
 description: |
   This image is used as part of the Charmed Kubeflow product. The controller allows users to
   create a custom resource "Notebook" (jupyter notebook).
-version: "1.10.0-rc.1"
+version: "1.10.0"
 license: Apache-2.0
 base: ubuntu@22.04
 services:
@@ -30,7 +30,7 @@ parts:
     plugin: go
     source: https://github.com/kubeflow/kubeflow
     source-type: git
-    source-tag: v1.10.0-rc.1
+    source-tag: v1.10.0
     build-snaps:
       - go/1.17/stable
     build-packages:


### PR DESCRIPTION
Closes https://warthogs.atlassian.net/browse/KF-7152
There were no changes to the images from `v1.10.0-rc.1`, just updated the version.
See [the tag diff](https://github.com/kubeflow/kubeflow/compare/v1.10.0-rc.1...v1.10.0) for reference.

Note than `jupyter-tensorflow-full` rock is being updated in https://github.com/canonical/kubeflow-rocks/pull/195.