### PR TITLE
chore: upgrade admission-webhook rock to v1.10.0

### DIFF
--- a/admission-webhook/rockcraft.yaml
+++ b/admission-webhook/rockcraft.yaml
@@ -1,8 +1,8 @@
-# From https://github.com/kubeflow/kubeflow/blob/v1.10.0-rc.1/components/admission-webhook/Dockerfile
+# From https://github.com/kubeflow/kubeflow/blob/v1.10.0/components/admission-webhook/Dockerfile
 name: admission-webhook
 base: ubuntu@22.04
 run-user: _daemon_
-version: 1.10.0-rc.1
+version: 1.10.0
 summary: An image for Kubeflow's admission-webhook
 description: |
   Admission webhook controller in general, intercepts requests to the Kubernetes API server, 
@@ -37,7 +37,7 @@ parts:
     build-snaps:
       - go/1.21/stable
     source: https://github.com/kubeflow/kubeflow.git
-    source-tag: v1.10.0-rc.1
+    source-tag: v1.10.0
     build-environment:
       - CGO_ENABLED: 0
       - GOOS: linux


### PR DESCRIPTION
Closes https://warthogs.atlassian.net/browse/KF-7153
There were no changes to the image from `v1.10.0-rc.1`, just updated the version.
See [the Dockerfile](https://github.com/kubeflow/kubeflow/blob/v1.10.0/components/admission-webhook/Dockerfile) for reference.