### PR TITLE
chore: upgrade tensorboards rocks to v1.10.0

### DIFF
--- a/tensorboard-controller/rockcraft.yaml
+++ b/tensorboard-controller/rockcraft.yaml
@@ -1,10 +1,10 @@
-# Source https://github.com/kubeflow/kubeflow/blob/v1.10.0-rc.1/components/tensorboard-controller/Dockerfile
+# Source https://github.com/kubeflow/kubeflow/blob/v1.10.0/components/tensorboard-controller/Dockerfile
 name: tensorboard-controller
 summary: An image for tensorboard controller
 description: |
   This image is used as part of the Charmed Kubeflow product. The controller needs 
   for providing the measurements and visualizations needed during the machine learning workflow.
-version: "1.10.0-rc.1"
+version: "1.10.0"
 license: Apache-2.0
 base: ubuntu@22.04
 services:
@@ -30,7 +30,7 @@ parts:
     plugin: go
     source: https://github.com/kubeflow/kubeflow
     source-type: git
-    source-tag: v1.10.0-rc.1
+    source-tag: v1.10.0
     source-subdir: components/tensorboard-controller
     build-snaps:
       - go/1.21/stable

--- a/tensorboards-web-app/rockcraft.yaml
+++ b/tensorboards-web-app/rockcraft.yaml
@@ -1,10 +1,10 @@
-# Based on https://github.com/kubeflow/kubeflow/blob/v1.10.0-rc.1/components/crud-web-apps/tensorboards/Dockerfile
+# Based on https://github.com/kubeflow/kubeflow/blob/v1.10.0/components/crud-web-apps/tensorboards/Dockerfile
 name: tensorboards-web-app
 summary: Tensorboards Web App
 description: |
   This web app is responsible for allowing the user to manipulate tensorboards in their Kubeflow
   cluster.
-version: "1.10.0-rc.1"
+version: "1.10.0"
 license: Apache-2.0
 base: ubuntu@22.04
 platforms:
@@ -32,7 +32,7 @@ parts:
     plugin: nil
     source: https://github.com/kubeflow/kubeflow
     source-type: git
-    source-tag: v1.10.0-rc.1
+    source-tag: v1.10.0
     source-depth: 1
     build-packages:
       - python3-venv
@@ -54,7 +54,7 @@ parts:
     plugin: nil
     source: https://github.com/kubeflow/kubeflow
     source-type: git
-    source-tag: v1.10.0-rc.1
+    source-tag: v1.10.0
     source-depth: 1
     build-snaps:
       - node/16/stable
@@ -76,7 +76,7 @@ parts:
     plugin: nil
     source: https://github.com/kubeflow/kubeflow
     source-type: git
-    source-tag: v1.10.0-rc.1
+    source-tag: v1.10.0
     source-depth: 1
     build-snaps:
       - node/16/stable
@@ -104,7 +104,7 @@ parts:
     plugin: nil
     source: https://github.com/kubeflow/kubeflow
     source-type: git
-    source-tag: v1.10.0-rc.1
+    source-tag: v1.10.0
     source-depth: 1
     build-packages:
       - python3-venv
@@ -128,7 +128,7 @@ parts:
   gunicorn:
     plugin: python
     source: https://github.com/kubeflow/kubeflow.git
-    source-tag: v1.10.0-rc.1
+    source-tag: v1.10.0
     source-depth: 1
     python-requirements:
     - components/crud-web-apps/tensorboards/backend/requirements.txt


### PR DESCRIPTION
Closes https://warthogs.atlassian.net/browse/KF-7154
No changes were made to the images, just updated the version.
For reference see the Dockerfiles for [controller](https://github.com/kubeflow/kubeflow/blob/v1.10.0/components/tensorboard-controller/Dockerfile) and [web-app](https://github.com/kubeflow/kubeflow/blob/v1.10.0/components/crud-web-apps/tensorboards/Dockerfile)