### PR TITLE
fix: empty rock-ci-metadata.yaml to ubnlock ci

### DIFF
--- a/codeserver-python/rock-ci-metadata.yaml
+++ b/codeserver-python/rock-ci-metadata.yaml
@@ -1,0 +1,1 @@
+integrations: []

--- a/jupyter-pytorch-full/rock-ci-metadata.yaml
+++ b/jupyter-pytorch-full/rock-ci-metadata.yaml
@@ -1,0 +1,1 @@
+integrations: []

--- a/jupyter-scipy/rock-ci-metadata.yaml
+++ b/jupyter-scipy/rock-ci-metadata.yaml
@@ -1,0 +1,1 @@
+integrations: []

--- a/jupyter-tensorflow-full/rock-ci-metadata.yaml
+++ b/jupyter-tensorflow-full/rock-ci-metadata.yaml
@@ -1,0 +1,1 @@
+integrations: []

--- a/rstudio-tidyverse/rock-ci-metadata.yaml
+++ b/rstudio-tidyverse/rock-ci-metadata.yaml
@@ -1,0 +1,1 @@
+integrations: []


### PR DESCRIPTION
Part of https://github.com/canonical/bundle-kubeflow/issues/1328