### PR TITLE
fix(dashboard): Fix logout button for oidc-authservice

### DIFF
--- a/centraldashboard/rockcraft.yaml
+++ b/centraldashboard/rockcraft.yaml
@@ -57,6 +57,10 @@ parts:
       set -xe
       cd ${CRAFT_PART_SRC}/components/centraldashboard/
 
+      # Revert due to https://github.com/canonical/bundle-kubeflow/issues/1259
+      # Must be undone once we migrate from oidc-gatekeeper charm
+      git revert c3f43187a42a768f717cb081fba304839d79d97d --no-edit
+
       # set environment variables
       export BUILD_COMMIT=$(git rev-parse HEAD)
 


### PR DESCRIPTION
Revert commit in upstream code that breaks the `logout` function for
oidc-authservice.

Fix canonical/bundle-kubeflow#1259

## Testing
For testing, refer to the issue. The image from this PR has been pushed to `docker.io/orfeask/kubeflow-centraldashboard:1.10.0-dirty`

## CI
CI is fixed in https://github.com/canonical/kubeflow-rocks/pull/248.