### PR TITLE
feat: `admission-webhook` create rocks-automation-ci.yaml

### DIFF
--- a/admission-webhook/rock-ci-metadata.yaml
+++ b/admission-webhook/rock-ci-metadata.yaml
@@ -1,0 +1,5 @@
+integrations:
+  - consumer-repository: https://github.com/canonical/admission-webhook-operator.git
+    replace-image:
+      - file: metadata.yaml
+        path: resources.oci-image.upstream-source


### PR DESCRIPTION
Closes: https://github.com/canonical/kubeflow-rocks/issues/210

This pr: 
- introduces `rock-ci-metadata.yaml` file for rock integration.
**note:** `workflow_dispatch` is already part of repo

For full file creation steps please refer to [this](https://github.com/canonical/pipelines-rocks/issues/200#issuecomment-3112245114) comment.