### PR TITLE
feat: update torch to 2.9.0

### DIFF
--- a/jupyter-pytorch-full/rockcraft.yaml
+++ b/jupyter-pytorch-full/rockcraft.yaml
@@ -95,6 +95,7 @@ parts:
       - CONDA_BIN: "/opt/conda/bin"
       - JUPYTERLAB_VERSION: "4.2.5"
       - JUPYTER_VERSION: "7.2.2"
+      # Following 3 envs diverge from upstream in order to fix CVEs
       - PYTORCH_VERSION: "2.9.0"
       - TORCHAUDIO_VERSION: "2.9.0"
       - TORCHVISION_VERSION: "0.24.0"


### PR DESCRIPTION
Closes: https://github.com/canonical/kserve-rocks/issues/210

- We bump the version of torch to highest available version compatible with python 3.11.
- I had to resolve some overlay conflict problems introduced with new rockcraft changes. I moved the overlay packages to conda-jupyter part. This part was conflicting if kept separate.
- Because of the new pytorch version i have to also bump the `TORCHAUDIO_VERSION` and `TORCHVISION_VERSION`

### Testing
I managed to build the image and run it in the deployment. The notebook also has correct version of the libraries. 

<img width="1406" height="660" alt="image" src="https://github.com/user-attachments/assets/42cdda49-ff5c-48c7-b4b7-fb0500c4e5f0" />
 

