### PR TITLE
fix: create config folders and `chown` them to `daemon` user for `jupyter-web-app`

### DIFF
--- a/jupyter-web-app/rockcraft.yaml
+++ b/jupyter-web-app/rockcraft.yaml
@@ -134,12 +134,6 @@ parts:
       # make logos dir
       mkdir -p $CRAFT_PART_INSTALL/src/apps/default/static/assets/logos
 
-  security-team-requirement:
-    plugin: nil
-    override-build: |
-      mkdir -p ${CRAFT_PART_INSTALL}/usr/share/rocks
-      (echo "# os-release" && cat /etc/os-release && echo "# dpkg-query" && dpkg-query -f '${db:Status-Abbrev},${binary:Package},${Version},${source:Package},${Source:Version}\n' -W) > ${CRAFT_PART_INSTALL}/usr/share/rocks/dpkg.query
-
   non-root-user:
     plugin: nil
     after:
@@ -149,3 +143,11 @@ parts:
       install -d -o 584792 -g 584792 -m 770 \
         etc/config \
         src/apps/default/static/assets/logos
+
+  security-team-requirement:
+    plugin: nil
+    after:
+      - non-root-user
+    override-build: |
+      mkdir -p ${CRAFT_PART_INSTALL}/usr/share/rocks
+      (echo "# os-release" && cat /etc/os-release && echo "# dpkg-query" && dpkg-query -f '${db:Status-Abbrev},${binary:Package},${Version},${source:Package},${Source:Version}\n' -W) > ${CRAFT_PART_INSTALL}/usr/share/rocks/dpkg.query


### PR DESCRIPTION
This PR modifies the `rockcraft.yaml` of rocks used by `jupyter-web-app` charm requiring to write config files to the filesystem.
With this PR, configuration folders are already created and owned by user `_daemon_`, so that the unprivileged `pebble` service running in the charm can read/write there.

## Manual installation of `cachetools` dependency
This PR also introduces the installation of `cachetools` dependency, as it was dropped by `google-auth` in https://github.com/googleapis/google-auth-library-python/pull/1590 and is causing the server to fail on startup
<details> <summary>Failure logs</summary>

```
2026-02-11T14:28:33.755Z [jupyter-ui] [2026-02-11 14:28:33 +0000] [31] [INFO] Starting gunicorn 25.0.3
2026-02-11T14:28:33.755Z [jupyter-ui] [2026-02-11 14:28:33 +0000] [31] [INFO] Listening at: http://0.0.0.0:5000 (31)
2026-02-11T14:28:33.755Z [jupyter-ui] [2026-02-11 14:28:33 +0000] [31] [INFO] Using worker: sync
2026-02-11T14:28:33.757Z [jupyter-ui] [2026-02-11 14:28:33 +0000] [32] [INFO] Booting worker with pid: 32
2026-02-11T14:28:33.779Z [jupyter-ui] [2026-02-11 14:28:33 +0000] [33] [INFO] Booting worker with pid: 33
2026-02-11T14:28:33.842Z [jupyter-ui] [2026-02-11 14:28:33 +0000] [34] [INFO] Booting worker with pid: 34
2026-02-11T14:28:35.224Z [jupyter-ui] [2026-02-11 14:28:35 +0000] [32] [ERROR] Exception in worker process
2026-02-11T14:28:35.224Z [jupyter-ui] Traceback (most recent call last):
2026-02-11T14:28:35.225Z [jupyter-ui]   File "/lib/python3.10/site-packages/gunicorn/arbiter.py", line 684, in spawn_worker
2026-02-11T14:28:35.225Z [jupyter-ui]     worker.init_process()
2026-02-11T14:28:35.225Z [jupyter-ui]   File "/lib/python3.10/site-packages/gunicorn/workers/base.py", line 136, in init_process
2026-02-11T14:28:35.225Z [jupyter-ui]     self.load_wsgi()
2026-02-11T14:28:35.225Z [jupyter-ui]   File "/lib/python3.10/site-packages/gunicorn/workers/base.py", line 148, in load_wsgi
2026-02-11T14:28:35.225Z [jupyter-ui]     self.wsgi = self.app.wsgi()
2026-02-11T14:28:35.225Z [jupyter-ui]   File "/lib/python3.10/site-packages/gunicorn/app/base.py", line 66, in wsgi
2026-02-11T14:28:35.225Z [jupyter-ui]     self.callable = self.load()
2026-02-11T14:28:35.225Z [jupyter-ui]   File "/lib/python3.10/site-packages/gunicorn/app/wsgiapp.py", line 57, in load
2026-02-11T14:28:35.225Z [jupyter-ui]     return self.load_wsgiapp()
2026-02-11T14:28:35.225Z [jupyter-ui]   File "/lib/python3.10/site-packages/gunicorn/app/wsgiapp.py", line 47, in load_wsgiapp
2026-02-11T14:28:35.225Z [jupyter-ui]     return util.import_app(self.app_uri)
2026-02-11T14:28:35.225Z [jupyter-ui]   File "/lib/python3.10/site-packages/gunicorn/util.py", line 377, in import_app
2026-02-11T14:28:35.225Z [jupyter-ui]     mod = importlib.import_module(module)
2026-02-11T14:28:35.225Z [jupyter-ui]   File "/usr/lib/python3.10/importlib/__init__.py", line 126, in import_module
2026-02-11T14:28:35.225Z [jupyter-ui]     return _bootstrap._gcd_import(name[level:], package, level)
2026-02-11T14:28:35.225Z [jupyter-ui]   File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
2026-02-11T14:28:35.225Z [jupyter-ui]   File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
2026-02-11T14:28:35.225Z [jupyter-ui]   File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked
2026-02-11T14:28:35.225Z [jupyter-ui]   File "<frozen importlib._bootstrap>", line 688, in _load_unlocked
2026-02-11T14:28:35.225Z [jupyter-ui]   File "<frozen importlib._bootstrap_external>", line 883, in exec_module
2026-02-11T14:28:35.225Z [jupyter-ui]   File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
2026-02-11T14:28:35.225Z [jupyter-ui]   File "/src/entrypoint.py", line 4, in <module>
2026-02-11T14:28:35.225Z [jupyter-ui]     from apps import default
2026-02-11T14:28:35.225Z [jupyter-ui]   File "/src/apps/default/__init__.py", line 5, in <module>
2026-02-11T14:28:35.225Z [jupyter-ui]     from ..common import create_app as create_default_app
2026-02-11T14:28:35.225Z [jupyter-ui]   File "/src/apps/common/__init__.py", line 4, in <module>
2026-02-11T14:28:35.225Z [jupyter-ui]     from .routes import bp as routes_bp
2026-02-11T14:28:35.225Z [jupyter-ui]   File "/src/apps/common/routes/__init__.py", line 5, in <module>
2026-02-11T14:28:35.225Z [jupyter-ui]     from . import delete, get, patch  # noqa: F401, E402
2026-02-11T14:28:35.225Z [jupyter-ui]   File "/src/apps/common/routes/get.py", line 6, in <module>
2026-02-11T14:28:35.225Z [jupyter-ui]     from .. import utils
2026-02-11T14:28:35.225Z [jupyter-ui]   File "/src/apps/common/utils.py", line 5, in <module>
2026-02-11T14:28:35.225Z [jupyter-ui]     from cachetools.func import ttl_cache
2026-02-11T14:28:35.225Z [jupyter-ui] ModuleNotFoundError: No module named 'cachetools'
2026-02-11T14:28:35.225Z [jupyter-ui] No module named 'cachetools'
2026-02-11T14:28:35.225Z [jupyter-ui] [2026-02-11 14:28:35 +0000] [32] [INFO] Worker exiting (pid: 32)
```

</detail>