### PR TITLE
chore: migrate to `_daemon_` user for Kubeflow KFAM rock

### DIFF
--- a/kfam/rockcraft.yaml
+++ b/kfam/rockcraft.yaml
@@ -8,6 +8,7 @@ description: Kubeflow Access Management API provides fine-grain user-namespace l
 version: "1.10.0"
 license: Apache-2.0
 base: ubuntu@22.04
+run-user: _daemon_
 
 platforms:
   amd64:
@@ -17,7 +18,6 @@ services:
     override: replace
     command: "/access-management"
     startup: enabled
-    user: ubuntu
 
 parts:
   security-team-requirement:
@@ -47,11 +47,3 @@ parts:
       cp -r third_party $CRAFT_PART_INSTALL/third_party
       cp -r /root/go/pkg/mod/github.com/hashicorp $CRAFT_PART_INSTALL/third_party/library/
 
-  non-root-user:
-    plugin: nil
-    after: [kfam]
-    overlay-script: |
-      # Create a user in the $CRAFT_OVERLAY chroot
-      groupadd -R $CRAFT_OVERLAY -g 1001 ubuntu
-      useradd -R $CRAFT_OVERLAY -M -r -u 1001 -g ubuntu ubuntu
- 


### PR DESCRIPTION
This PR migrates the default user from `ubuntu` to `_daemon_`.

This rock was manually tested by publishing it to my [dockerhub](https://hub.docker.com/repository/docker/dariofaccin/kfam/tags/1.10.0-955f91f/sha256-00d0db861dc5197713f9e3bd1743efc2fbba4286d90ba96e0c20be7bdbb4b20f).

<details>

<summary>Logs from container after the change</summary>

```
kubectl logs -n kubeflow kubeflow-profiles-0 -c kubeflow-kfam --follow
2026-03-11T09:00:00.765Z [pebble] HTTP API server listening on ":38813".
2026-03-11T09:00:00.765Z [pebble] Started daemon.
2026-03-11T09:00:00.769Z [pebble] POST /v1/identities 1.638651ms 200
2026-03-11T09:00:04.314Z [pebble] GET /v1/plan?format=yaml 96.541µs 200
2026-03-11T09:00:04.317Z [pebble] POST /v1/layers 1.3765ms 200
2026-03-11T09:00:04.318Z [pebble] GET /v1/notices?timeout=30s 3.383015836s 200
2026-03-11T09:00:04.321Z [pebble] POST /v1/services 1.190716ms 202
2026-03-11T09:00:04.322Z [pebble] GET /v1/notices?after=2026-03-11T09%3A00%3A04.317541989Z&timeout=30s 3.379812ms 200
2026-03-11T09:00:04.322Z [pebble] Service "kubeflow-kfam" starting: /access-management -cluster-admin admin -userid-header kubeflow-userid -userid-prefix ""
2026-03-11T09:00:04.329Z [kubeflow-kfam] time="2026-03-11T09:00:04Z" level=info msg="Server started"
2026-03-11T09:00:05.327Z [pebble] GET /v1/notices?after=2026-03-11T09%3A00%3A04.321379494Z&timeout=30s 1.005207928s 200
2026-03-11T09:00:05.327Z [pebble] GET /v1/changes/2/wait?timeout=4.000s 1.006199066s 200
2026-03-11T09:00:06.189Z [pebble] GET /v1/plan?format=yaml 96.092µs 200
2026-03-11T09:00:07.601Z [pebble] GET /v1/plan?format=yaml 100.535µs 200
2026-03-11T09:00:08.409Z [pebble] GET /v1/plan?format=yaml 97.73µs 200
2026-03-11T09:00:34.321Z [kubeflow-kfam] 2026/03/11 09:00:34 GET /metrics PrometheusMetrics 1.367211ms
2026-03-11T09:00:35.329Z [pebble] GET /v1/notices?after=2026-03-11T09%3A00%3A05.32377768Z&timeout=30s 30.001048346s 200
2026-03-11T09:01:04.322Z [kubeflow-kfam] 2026/03/11 09:01:04 GET /metrics PrometheusMetrics 1.819018ms
2026-03-11T09:01:05.329Z [pebble] GET /v1/notices?after=2026-03-11T09%3A00%3A05.32377768Z&timeout=30s 30.000460666s 200
2026-03-11T09:01:34.322Z [kubeflow-kfam] 2026/03/11 09:01:34 GET /metrics PrometheusMetrics 2.243203ms
2026-03-11T09:01:35.330Z [pebble] GET /v1/notices?after=2026-03-11T09%3A00%3A05.32377768Z&timeout=30s 30.00098184s 200
2026-03-11T09:02:04.321Z [kubeflow-kfam] 2026/03/11 09:02:04 GET /metrics PrometheusMetrics 1.352349ms
2026-03-11T09:02:05.332Z [pebble] GET /v1/notices?after=2026-03-11T09%3A00%3A05.32377768Z&timeout=30s 30.000943177s 200
2026-03-11T09:02:34.321Z [kubeflow-kfam] 2026/03/11 09:02:34 GET /metrics PrometheusMetrics 1.80979ms
2026-03-11T09:02:35.334Z [pebble] GET /v1/notices?after=2026-03-11T09%3A00%3A05.32377768Z&timeout=30s 30.001172159s 200
2026-03-11T09:03:04.321Z [kubeflow-kfam] 2026/03/11 09:03:04 GET /metrics PrometheusMetrics 1.148177ms
2026-03-11T09:03:05.334Z [pebble] GET /v1/notices?after=2026-03-11T09%3A00%3A05.32377768Z&timeout=30s 30.000187451s 200
```

</details>