### PR TITLE
fix: use correct python packages in `jupyter-pytorch-full` image

### DIFF
--- a/jupyter-pytorch-full/rockcraft.yaml
+++ b/jupyter-pytorch-full/rockcraft.yaml
@@ -184,7 +184,7 @@ parts:
         dill==0.3.9 \
         ipympl==0.9.6 \
         matplotlib==3.10.0 \
-        numpy==2.4.4 \
+        numpy==2.0.2 \
         pandas==2.2.3 \
         scikit-image==0.25.1 \
         scikit-learn==1.6.1 \

--- a/jupyter-pytorch-full/rockcraft.yaml
+++ b/jupyter-pytorch-full/rockcraft.yaml
@@ -184,7 +184,7 @@ parts:
         dill==0.3.9 \
         ipympl==0.9.6 \
         matplotlib==3.10.0 \
-        numpy==1.26.4 \
+        numpy==2.4.4 \
         pandas==2.2.3 \
         scikit-image==0.25.1 \
         scikit-learn==1.6.1 \

--- a/jupyter-pytorch-full/rockcraft.yaml
+++ b/jupyter-pytorch-full/rockcraft.yaml
@@ -179,18 +179,18 @@ parts:
 
       # Install the jupyter-pytorch-full requirements
       "${CONDA_BIN}/mamba" install -y -q \
-        bokeh==3.6.3 \
-        cloudpickle==3.1.1 \
-        dill==0.3.9 \
-        ipympl==0.9.6 \
-        matplotlib==3.10.0 \
-        numpy==1.26.4 \
-        pandas==2.2.3 \
-        scikit-image==0.25.1 \
-        scikit-learn==1.6.1 \
-        scipy==1.15.1 \
+        bokeh==3.3.4 \
+        cloudpickle==2.2.1 \
+        dill==0.3.8 \
+        ipympl==0.9.4 \
+        matplotlib==3.8.4 \
+        numpy==1.24.4 \
+        pandas==2.1.4 \
+        scikit-image==0.22.0 \
+        scikit-learn==1.3.2 \
+        scipy==1.11.3 \
         seaborn==0.13.2 \
-        xgboost==2.1.4
+        xgboost==1.7.6
 
       "${CONDA_BIN}/mamba" clean -a -f -y
 

--- a/jupyter-pytorch-full/rockcraft.yaml
+++ b/jupyter-pytorch-full/rockcraft.yaml
@@ -179,18 +179,18 @@ parts:
 
       # Install the jupyter-pytorch-full requirements
       "${CONDA_BIN}/mamba" install -y -q \
-        bokeh==3.3.4 \
-        cloudpickle==2.2.1 \
-        dill==0.3.8 \
-        ipympl==0.9.4 \
-        matplotlib==3.8.4 \
-        numpy==1.24.4 \
-        pandas==2.1.4 \
-        scikit-image==0.22.0 \
-        scikit-learn==1.3.2 \
-        scipy==1.11.3 \
+        bokeh==3.6.3 \
+        cloudpickle==3.1.1 \
+        dill==0.3.9 \
+        ipympl==0.9.6 \
+        matplotlib==3.10.0 \
+        numpy==1.26.4 \
+        pandas==2.2.3 \
+        scikit-image==0.25.1 \
+        scikit-learn==1.6.1 \
+        scipy==1.15.1 \
         seaborn==0.13.2 \
-        xgboost==1.7.6
+        xgboost==2.1.4
 
       "${CONDA_BIN}/mamba" clean -a -f -y
 

--- a/jupyter-pytorch-full/rockcraft.yaml
+++ b/jupyter-pytorch-full/rockcraft.yaml
@@ -206,7 +206,7 @@ parts:
       mkdir -p "${CRAFT_PART_INSTALL}/${CONDA_DIR}" \
       "${CRAFT_PART_INSTALL}/etc" \
       "${CRAFT_PART_INSTALL}/${HOME}" \
-      "${CRAFT_PART_INSTALL}/${HOME_TMP}" \
+      "${CRAFT_PART_INSTALL}/${HOME_TMP}"
 
       # Write some config files for activating conda in user sessions
       chmod 2775 ${CRAFT_PART_INSTALL}/${CONDA_DIR}

--- a/jupyter-pytorch-full/rockcraft.yaml
+++ b/jupyter-pytorch-full/rockcraft.yaml
@@ -178,6 +178,10 @@ parts:
         torchaudio==${TORCHAUDIO_VERSION}
 
       # Install the jupyter-pytorch-full requirements
+      # NOTE: the version of numpy is higher than the corresponding upstream one in order to have
+      # the same version of pandas as upstream, because of pandas' requirements - i.e., for pandas
+      # 2.2.3 (upstream), numpy >= 2.0 (unlike upstream, == 1.26.4) is recommended:
+      # https://github.com/pandas-dev/pandas/blob/v2.2.3/pyproject.toml#L9-L11
       "${CONDA_BIN}/mamba" install -y -q \
         bokeh==3.6.3 \
         cloudpickle==3.1.1 \


### PR DESCRIPTION
This PR bumps python dependencies for `jupyter-pytorch-full` rock.

This PR closes #273.