### PR TITLE
chore(jupyter-web-app): migrate to `1.11.0-rc.1`

### DIFF
--- a/jupyter-web-app/rockcraft.yaml
+++ b/jupyter-web-app/rockcraft.yaml
@@ -1,10 +1,10 @@
-# Based on https://github.com/kubeflow/notebooks/blob/v1.11.0-rc.0/components/crud-web-apps/jupyter/Dockerfile
+# Based on https://github.com/kubeflow/notebooks/blob/v1.11.0-rc.1/components/crud-web-apps/jupyter/Dockerfile
 name: jupyter-web-app
 summary: An image for Jupyter UI
 description: |
   This image is used as part of Charmed Kubeflow product. Jupyter UI web application provides
   users with web UI to access and manipulate Jupyter Notebooks in Charmed Kubeflow.
-version: 1.11.0-rc.0
+version: 1.11.0-rc.1
 license: Apache-2.0
 base: ubuntu@24.04
 platforms:
@@ -25,7 +25,7 @@ parts:
     plugin: nil
     source: https://github.com/kubeflow/notebooks
     source-type: git
-    source-tag: v1.11.0-rc.0
+    source-tag: v1.11.0-rc.1
     source-depth: 1
     build-packages:
       - python3-venv
@@ -49,7 +49,7 @@ parts:
     plugin: nil
     source: https://github.com/kubeflow/notebooks
     source-type: git
-    source-tag: v1.11.0-rc.0
+    source-tag: v1.11.0-rc.1
     source-depth: 1
     build-snaps:
       - node/24/stable
@@ -71,7 +71,7 @@ parts:
     plugin: nil
     source: https://github.com/kubeflow/notebooks
     source-type: git
-    source-tag: v1.11.0-rc.0
+    source-tag: v1.11.0-rc.1
     source-depth: 1
     build-snaps:
       - node/24/stable
@@ -97,7 +97,7 @@ parts:
     plugin: python
     source: https://github.com/kubeflow/notebooks
     source-type: git
-    source-tag: v1.11.0-rc.0
+    source-tag: v1.11.0-rc.1
     source-depth: 1
     python-requirements:
     - components/crud-web-apps/jupyter/backend/requirements.txt
@@ -109,7 +109,7 @@ parts:
     plugin: nil
     source: https://github.com/kubeflow/notebooks
     source-type: git
-    source-tag: v1.11.0-rc.0
+    source-tag: v1.11.0-rc.1
     source-depth: 1
     build-packages:
       - python3-venv


### PR DESCRIPTION
This PR updates `jupyter-web-app` rock to new version `1.11.0-rc.1`.

Ref: #276.