### PR TITLE
chore: update profile-controller rock to tag `2.0.0-rc.0-ambient1`

### DIFF
--- a/profile-controller/rockcraft.yaml
+++ b/profile-controller/rockcraft.yaml
@@ -2,7 +2,7 @@
 
 name: profile-controller
 base: ubuntu@24.04
-version: 2.0.0-rc.0-ambient
+version: 2.0.0-rc.0-ambient1
 summary: Controller for Kubeflow Profile objects
 description: Controller for Kubeflow Profile objects
 license: Apache-2.0
@@ -29,7 +29,7 @@ parts:
     plugin: go
     source-type: git
     source: https://github.com/canonical/kubeflow-dashboard
-    source-tag: v2.0.0-rc.0-ambient
+    source-tag: v2.0.0-rc.0-ambient1
     source-subdir: components/profile-controller
     build-environment:
       - CGO_ENABLED: 0

--- a/profile-controller/rockcraft.yaml
+++ b/profile-controller/rockcraft.yaml
@@ -1,4 +1,4 @@
-# Constructed from https://github.com/canonical/kubeflow-dashboard/blob/v2.0.0-rc.0-ambient/components/profile-controller/Dockerfile
+# Constructed from https://github.com/canonical/kubeflow-dashboard/blob/v2.0.0-rc.0-ambient1/components/profile-controller/Dockerfile
 
 name: profile-controller
 base: ubuntu@24.04


### PR DESCRIPTION
Closes #297 
Updates the profile-controller rock to have the changes from https://github.com/canonical/kubeflow-dashboard/pull/33