### PR TITLE
chore: add CA certificates to profile controller rock

### DIFF
--- a/profile-controller/rockcraft.yaml
+++ b/profile-controller/rockcraft.yaml
@@ -37,6 +37,8 @@ parts:
     build-snaps:
       - go/1.22/stable
     # Override-build because we want to move the hashicorp library folder
+    overlay-packages:
+      - ca-certificates
     override-build: |
       cd $CRAFT_PART_SRC_WORK
 


### PR DESCRIPTION
This PR adds `ca-certificates` overlay package to profile controller rock.

This PR closes #296.