### PR TITLE
fix: Force rebuild `jupyter-pytorch-full`

### DIFF
--- a/jupyter-pytorch-full/rockcraft.yaml
+++ b/jupyter-pytorch-full/rockcraft.yaml
@@ -1,3 +1,4 @@
+# force CI rebuild
 # Based on the following Dockerfiles:
 # https://github.com/kubeflow/kubeflow/blob/v1.10.0/components/example-notebook-servers/base/Dockerfile
 # https://github.com/kubeflow/kubeflow/blob/v1.10.0/components/example-notebook-servers/jupyter/Dockerfile

--- a/jupyter-pytorch-full/tox.ini
+++ b/jupyter-pytorch-full/tox.ini
@@ -34,7 +34,7 @@ commands =
              ROCK="$\{NAME\}_$\{VERSION\}_$\{ARCH\}.rock" && \
              DOCKER_IMAGE=$NAME:$VERSION && \
              echo "Exporting $ROCK to docker as $DOCKER_IMAGE" && \
-             skopeo --insecure-policy copy oci-archive:$ROCK docker-daemon:$DOCKER_IMAGE'
+             rockcraft.skopeo --insecure-policy copy oci-archive:$ROCK docker-daemon:$DOCKER_IMAGE'
 
 [testenv:sanity]
 passenv = *


### PR DESCRIPTION
Note that this PR fixes the [CVE-2026-44727](https://nvd.nist.gov/vuln/detail/CVE-2026-44727).

We can confirm it by running:
```
charmcraft pack
tox -e export-to-docker
trivy image jupyter-scipy:1.10 --format json | grep CVE-2026-44727
```

Closes #306